### PR TITLE
Add Caddy as a Reverse Proxy and Gunicorn as Application Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,22 @@ flask run
    ```
 
    This will build the Docker image and run the container, exposing the application on port 5000.
+
+# Another Alternative, you can use Docker compose file to run the applicaton:
+  - Build and start the services with Docker Compose:
+
+    ```bash
+    docker-compose up --build
+    ```
+   This command will build the Flask app's Docker image, set up MongoDB with data persistence, and configure Caddy as the reverse proxy.
+   
+   ### Accessing the Application
+
+      - Flask App: Access the application through Caddy on http://localhost:5000.
+
+   ### Stopping the Services
+
+      To stop the services, use:
+
+      ```bash
+      docker-compose down

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,6 @@
 from flask import Flask
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 from app.services.schema_data import SchemaManager
 from app.services.cypher_generator import CypherQueryGenerator
 from app.services.metta_generator import MeTTa_Query_Generator
@@ -7,6 +9,12 @@ from app.services.llm_handler import LLMHandler
 from app.persistence.storage_service import StorageService
 
 app = Flask(__name__)
+
+limiter = Limiter(
+    get_remote_address,
+    app=app,
+    default_limits=["200 per minute"],
+)
 
 mongo_init()
 

--- a/app/services/metta_generator.py
+++ b/app/services/metta_generator.py
@@ -117,7 +117,7 @@ class MeTTa_Query_Generator(QueryGeneratorInterface):
         return metta_output
 
 
-    def run_query(self, query_code, limit):
+    def run_query(self, query_code, limit=None):
         return self.metta.run(query_code)
 
     def parse_and_serialize(self, input, schema, all_properties):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+services:
+  flask_catalog:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+    command: gunicorn -w 16 --bind 0.0.0.0:8000 wsgi:app
+    restart: always
+    depends_on:
+      - mongodb
+    environment:
+      - MONGO_URI=mongodb://mongodb:27017/annotation
+
+  mongodb:
+    image: mongo:latest
+    volumes:
+      - mongo_data:/data/db
+    ports:
+      - "27018:27017"
+    restart: always
+
+  caddy:
+    image: caddy:latest
+    ports:
+      - "5000:5000"
+    volumes:
+      - caddy_data:/data
+      - caddy_config:/config
+    command: caddy reverse-proxy --from http://localhost:5000 --to http://flask_catalog:8000
+    restart: always
+    depends_on:
+      - flask_catalog
+
+volumes:
+  mongo_data:
+  caddy_data:
+  caddy_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - .:/app
     ports:
       - "8000:8000"
-    command: gunicorn -w 16 --bind 0.0.0.0:8000 wsgi:app
+    command: gunicorn -w 16 --bind 0.0.0.0:8000 run:app
     restart: always
     depends_on:
       - mongodb

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ PyJWT == 2.9.0
 pymongoose == 1.3.8
 openai == 1.51.2
 pytest == 8.3.3
+gunicorn == 23.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pymongoose == 1.3.8
 openai == 1.51.2
 pytest == 8.3.3
 gunicorn == 23.0.0
+Flask-Limiter == 3.8.0 

--- a/run.py
+++ b/run.py
@@ -1,8 +1,6 @@
 from app import app
-from db import mongo_init
 
 if __name__ == '__main__':
-    mongo_init()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(debug=True, host='0.0.0.0', port=8000)
     
     

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0', port=8000)

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,4 +1,0 @@
-from app import app
-
-if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=8000)


### PR DESCRIPTION
- Configure Caddy as a reverse proxy web server to manage incoming requests and improve performance.
- Integrate Gunicorn as the application server to serve the application in a production-ready, efficient setup.
- Add docker-compose.yml for deployment, defining Mongodb, Caddy and Gunicorn services to streamline container orchestration and setup.
- Change Flask application port to 8000 for internal application requests.
- Configure Caddy reverse proxy on port 5000 to route incoming traffic 
- Update readme
- Add rate limiter to limit the request for single ip to 200 request per minute