### PR TITLE
Question and Anwer fields and New API endpoint

### DIFF
--- a/app/models/storage.py
+++ b/app/models/storage.py
@@ -13,6 +13,7 @@ class Storage(Schema):
     query = None
     title = None
     summary = None
+    answer = None
 
     def __init__(self, **kwargs):
         self.schema = {
@@ -32,6 +33,12 @@ class Storage(Schema):
                 "type": Types.String,
                 "required": True,
             },
+            "question": {
+                "type": Types.String
+            },
+            "answer": {
+                "type": Types.String
+            },
             "created_at": {
                 "type": Types.Date,
                 "required": True,
@@ -47,4 +54,4 @@ class Storage(Schema):
         super().__init__(self.schema_name, self.schema, kwargs)
 
     def __str__(self):
-        return f"user_id: {self.user_id}, query: {self.query}, title: {self.title}, summary: {self.summary}"
+        return f"user_id: {self.user_id}, query: {self.query}, title: {self.title}, summary: {self.summary}, question: {self.question}, answer: {self.answer}"

--- a/app/persistence/storage_service.py
+++ b/app/persistence/storage_service.py
@@ -4,12 +4,14 @@ class StorageService():
     def __init__(self):
         pass
     
-    def save(self, user_id, data, title, summary):
+    def save(self, user_id, data, title, summary, question, answer):
         data = Storage(
                 user_id=user_id,
                 query=data,
                 title=title,
-                summary=summary
+                summary=summary,
+                question=question,
+                answer=answer
                 )
 
         id = data.save()
@@ -27,9 +29,13 @@ class StorageService():
         data = Storage.find_by_id(id)
         return data
 
-    def get_user_query(self, user_id, query):
-        data = Storage.find_one({"user_id": user_id, "query": query})
+    def get_user_query(self, annotation_id, user_id, query):
+        data = Storage.find_one({"_id": annotation_id, "user_id": user_id, "query": query})
         return data
     
     def update(self, id, data):
         data = Storage.update({"_id": id}, {"$set": data}, many=False)
+
+    def delete(self, id):
+        data = Storage.delete({"_id": id})
+        return data

--- a/app/services/graph_handler.py
+++ b/app/services/graph_handler.py
@@ -139,17 +139,12 @@ class Graph_Summarizer:
         
         return self.descriptions
 
-
-    def get_graph_info(self):
-        # get the graph summary from the annotation endpoint to get the summary of the graph
-        pass
-
-    def summary(self,graph,user_query=None,graph_id=None):
+    def summary(self,graph,user_query=None,graph_id=None, summary=None):
         prev_summery=[]
         try:
 
             if graph_id:
-                graph_summary = self.get_graph_info()
+                graph_summary = summary
                 if user_query:
                     prompt = SUMMARY_PROMPT_BASED_ON_USER_QUERY.format(description=graph_summary,user_query=user_query)
                 else:

--- a/app/services/llm_handler.py
+++ b/app/services/llm_handler.py
@@ -27,7 +27,7 @@ class LLMHandler:
         title = self.model.generate(prompt)
         return title
 
-    def generate_summary(self, graph):
+    def generate_summary(self, graph, user_query=None,graph_id=None, summary=None):
         summarizer = Graph_Summarizer(self.model)
-        summary = summarizer.ai_summarizer(graph)
+        summary = summarizer.summary(graph, user_query, graph_id, summary)
         return summary


### PR DESCRIPTION
- Add question and answer fields to the mongodb database
- Add new api endpoint to delete annotation and update title of the annotation
- **Query API Endpoint Update:**

    The query API endpoint has been updated with logic to handle window-based queries:
        - **For New Window**: If the user generates a new query (question) in a new window, the query will be saved in the database along with a new title and summary.
        - **For Same Window**: If the user generates the same query (question) in the same window, the system will fetch the existing entry from the database and update only the updated_at field to reflect the new timestamp.
        - **New Query**: When a new request/question is generated, a new title and summary will be generated and saved in the database with the query, title, and summary associated with the user.
        
- Fix issue: #35 