### PR TITLE
Fix: Initialize node and edge counts to zero to prevent schema errors

### DIFF
--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -350,8 +350,8 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             count_result = results[1]
         else:
             count_result = None
-        node_count = None
-        edge_count = None
+        node_count = 0
+        edge_count = 0
         nodes = []
         edges = []
         node_dict = {}


### PR DESCRIPTION
Ensure node and edge counts default to zero when query returns no results, avoiding errors with MongoDB schema.