### PR TITLE
Add Support for "NOT" Operator to Negate Nodes, Properties, Relationships in Query Generatio and Code refactoring

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -135,9 +135,7 @@ def process_query(current_user_id):
 
         if existing_query is None:
             title = llm.generate_title(query_code)
-            summary  = llm.generate_summary(response_data)
-            if summary is None: 
-                summary = 'Graph to big could not summarize'
+            summary = llm.generate_summary(response_data) if llm.generate_summary(response_data) else 'Graph to big could not summarize'
             answer = llm.generate_summary(response_data, question, True, summary) if question else None
             node_count = response_data['node_count']
             edge_count = response_data['edge_count'] if "edge_count" in response_data else 0

--- a/app/routes.py
+++ b/app/routes.py
@@ -135,7 +135,9 @@ def process_query(current_user_id):
 
         if existing_query is None:
             title = llm.generate_title(query_code)
-            summary = llm.generate_summary(response_data) if llm.generate_summary(response_data) else 'Graph to big could not summarize'
+            summary  = llm.generate_summary(response_data)
+            if summary is None: 
+                summary = 'Graph to big could not summarize'
             answer = llm.generate_summary(response_data, question, True, summary) if question else None
             node_count = response_data['node_count']
             edge_count = response_data['edge_count'] if "edge_count" in response_data else 0

--- a/app/routes.py
+++ b/app/routes.py
@@ -4,7 +4,7 @@ import json
 import yaml
 import os
 import threading
-from app import app, databases, schema_manager, db_instance
+from app import app, schema_manager, db_instance
 from app.lib import validate_request
 from flask_cors import CORS
 from app.lib import limit_graph

--- a/app/services/graph_handler.py
+++ b/app/services/graph_handler.py
@@ -141,7 +141,6 @@ class Graph_Summarizer:
 
     def summary(self,graph,user_query=None,graph_id=None, summary=None):
         prev_summery=[]
-        response = None
         try:
 
             if graph_id:

--- a/app/services/graph_handler.py
+++ b/app/services/graph_handler.py
@@ -141,6 +141,7 @@ class Graph_Summarizer:
 
     def summary(self,graph,user_query=None,graph_id=None, summary=None):
         prev_summery=[]
+        response = None
         try:
 
             if graph_id:


### PR DESCRIPTION
* The changes allow the generation of Cypher queries that can negate specific nodes, node properties, or entire relationships based on the provided logic

Key Features:

   1.  Negating Nodes:
       *  The ability to exclude specific node types from the query results. For example, you can now request all nodes except those of type gene.
        Example Request
```
       {
  "requests": {
    "nodes": [
      {
        "node_id": "n1",
        "id": "",
        "type": "gene",
        "properties": {}
      }
    ],
    "predicates": [],
    "logic": {
      "children": [
        {
          "operator": "NOT",
          "nodes": {
            "node_id": "n1"
          }
        }
      ]
    }
  }
}

```
 Generated Query: `MATCH (n1) WHERE NOT (n1: gene) RETURN n1`
 
2. Negating Node Properties: 
    * The ability to exclude nodes that have specific properties. For instance, you can now retrieve nodes that do not have a particular protein_name property.
    
    Example Request:
```
       {
  "requests": {
    "nodes": [
      {
        "node_id": "n1",
        "id": "",
        "type": "transcript",
        "properties": {}
      },
      {
        "node_id": "n2",
        "id": "",
        "type": "protein",
        "properties": {}
      }
    ],
    "predicates": [
      {
        "predicate_id": "p1",
        "type": "translates to",
        "source": "n1",
        "target": "n2"
      }
    ],
    "logic": {
      "children": [
        {
          "operator": "NOT",
          "nodes": {
            "node_id": "n2",
            "properties": {
              "protein_name": "MKKS"
            }
          }
        },
        {
          "operator": "NOT",
          "nodes": {
            "node_id": "n1",
            "properties": {
              "transcript_name": "SNAP25-218"
            }
          }
        }
      ]
    }
  }
}

```

Generated Query: `MATCH (n1:transcript), (n1)-[r0:translates_to]->(n2:protein) WHERE n2.protein_name <> 'MKKS' AND n1.transcript_name <> 'SNAP25-218' RETURN r0, n1, n2`

3. Negating Relationships
   * The ability to exclude specific types of relationships. For example, the query can now exclude relationships where gene is translated to transcript.
   
   Example Request
   
 ```
  {
  "requests": {
    "nodes": [
      {
        "node_id": "n1",
        "id": "",
        "type": "transcript",
        "properties": {}
      },
      {
        "node_id": "n2",
        "id": "",
        "type": "protein",
        "properties": {}
      }
    ],
    "predicates": [
      {
        "predicate_id": "p1",
        "type": "translates to",
        "source": "n1",
        "target": "n2"
      }
    ],
    "logic": {
      "children": [
        {
          "operator": "NOT",
          "predicates": {
            "predicate_id": "p1"
          }
        }
      ]
    }
  }
}

```

Generated Query: `MATCH (n1)-[p1]->(n2) WHERE type(p1) <> 'translates_to' RETURN p1, n1, n2`

