### PR TITLE
Fix LLM Response For Empty Graphs

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -135,10 +135,12 @@ def process_query(current_user_id):
 
         if existing_query is None:
             title = llm.generate_title(query_code)
-            summary = llm.generate_summary(response_data)
-            
-            if summary is None:
-                 summary = 'Graph too big, could not summarize'
+
+            if not response_data.get('nodes') and not response_data.get('edges'):
+                summary = 'No data found for the query'
+            else:
+                summary = llm.generate_summary(response_data) or 'Graph too big, could not summarize'
+
             answer = llm.generate_summary(response_data, question, True, summary) if question else None
             node_count = response_data['node_count']
             edge_count = response_data['edge_count'] if "edge_count" in response_data else 0

--- a/app/services/graph_handler.py
+++ b/app/services/graph_handler.py
@@ -141,6 +141,7 @@ class Graph_Summarizer:
 
     def summary(self,graph,user_query=None,graph_id=None, summary=None):
         prev_summery=[]
+        response = None
         try:
 
             if graph_id:


### PR DESCRIPTION
Ensures that empty graph return the message "No data found for the query" without invoking the LLM