### PR TITLE
Split Total Count and Count by Label & Return Node Properties by Default

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -81,7 +81,7 @@ def process_query(current_user_id):
     if properties:
         properties = bool(strtobool(properties))
     else:
-        properties = False
+        properties = True
 
     if limit:
         try:

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -295,6 +295,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             {return_clause}
         '''
 
+        # start building query for counting by label for both ndoe and edges
         label_clause = (
             'WITH DISTINCT ' +
             ' + '.join([f"labels({n})" for n in query_clauses['list_of_node_ids']]) +


### PR DESCRIPTION
Split Count Queries:
1.  Separate the count query into two distinct queries:
       - One for counting the total number of nodes and edges.
       - One for counting by label for both nodes and edges.

2. Node Properties:
    - Modify the logic to return node properties by default as part of the response.