### PR TITLE
Optimize Count Operations and Offload Aggregation to Backend

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -117,7 +117,9 @@ def process_query(current_user_id):
         
         # Run the query and parse the results
         result = db_instance.run_query(query_code, run_count)
-        response_data = db_instance.parse_and_serialize(result, schema_manager.schema, properties)
+        graph_components = {"nodes": requests['nodes'], "predicates": 
+                            requests['predicates'], "properties": properties}
+        response_data = db_instance.parse_and_serialize(result, schema_manager.schema, graph_components)
 
         # Extract node types
         nodes = requests['nodes']

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -88,9 +88,12 @@ class CypherQueryGenerator(QueryGeneratorInterface):
 
     def query_Generator(self, requests, node_map, limit=None, node_only=False):
         nodes = requests['nodes']
+        predicate_map = {}
 
         if "predicates" in requests:
             predicates = requests["predicates"]
+            for predicate in predicates:
+                predicate_map[predicate['predicate_id']] = predicate
         else:
             predicates = None
 
@@ -110,7 +113,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             list_of_node_ids = []
             # Case when there are no predicates
             for node in nodes:
-                var_name = f"n_{node['node_id']}"
+                var_name = f"{node['node_id']}"
                 match_no_preds.append(self.match_node(node, var_name))
                 if node['properties']:
                     where_no_preds.extend(self.where_construct(node, var_name))
@@ -128,10 +131,11 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                     "list_of_node_ids": list_of_node_ids,
                     "predicates": predicates
                 }
-            count = self.construct_count_clause(query_clauses)
+            count = self.construct_count_clause(query_clauses, node_map, predicate_map)
             cypher_queries.extend(count)
         else:
-            for i, predicate in enumerate(predicates):
+            for predicate in predicates:
+                predicate_id = predicate['predicate_id']
                 predicate_type = predicate['type'].replace(" ", "_").lower()
                 source_node = node_map[predicate['source']]
                 target_node = node_map[predicate['target']]
@@ -144,8 +148,8 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                 target_match = self.match_node(target_node, target_var)
                 where_preds.extend(self.where_construct(target_node, target_var))
 
-                match_preds.append(f"({source_var})-[r{i}:{predicate_type}]->{target_match}")
-                return_preds.append(f"r{i}")
+                match_preds.append(f"({source_var})-[{predicate_id}:{predicate_type}]->{target_match}")
+                return_preds.append(predicate_id)
 
                 used_nodes.add(predicate['source'])
                 used_nodes.add(predicate['target'])
@@ -154,7 +158,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
 
             for node_id, node in node_map.items():
                 if node_id not in used_nodes:
-                    var_name = f"n_{node_id}"
+                    var_name = f"{node_id}"
                     match_no_preds.append(self.match_node(node, var_name))
                     where_no_preds.extend(self.where_construct(node, var_name))
                     return_no_preds.append(var_name)
@@ -175,7 +179,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                     "return_preds": return_preds,
                     "predicates": predicates
                 }
-                count = self.construct_count_clause(query_clauses)
+                count = self.construct_count_clause(query_clauses, node_map, predicate_map)
                 cypher_queries.extend(count)
             else:
                 query_clauses = {
@@ -192,7 +196,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                 cypher_query = self.construct_union_clause(query_clauses, limit)
                 cypher_queries.append(cypher_query)
 
-                count = self.construct_count_clause(query_clauses)
+                count = self.construct_count_clause(query_clauses, node_map, predicate_map)
                 cypher_queries.extend(count)
         return cypher_queries
     
@@ -251,7 +255,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         query = self.construct_call_clause(clauses, limit)
         return query
 
-    def construct_count_clause(self, query_clauses):
+    def construct_count_clause(self, query_clauses, node_map, predicate_map):
         match_no_clause = ''
         where_no_clause = ''
         match_clause = ''
@@ -281,8 +285,9 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             collect_node_and_edge += f"COLLECT(DISTINCT {node_ids}) AS {node_ids}_count, "
         
         if "return_preds" in query_clauses:
-            for i, predicate in enumerate(query_clauses['predicates']):
-                collect_node_and_edge += f"COLLECT(DISTINCT r{i}) AS r{i}_count, "
+            for predicate in query_clauses['predicates']:
+                predicate_id = predicate['predicate_id']
+                collect_node_and_edge += f"COLLECT(DISTINCT {predicate_id}) AS {predicate_id}_count, "
         collect_node_and_edge = f"WITH {collect_node_and_edge.rstrip(', ')}"
 
 
@@ -311,86 +316,23 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         '''
 
         # start building query for counting by label for both ndoe and edges
-        label_clause = (
-            'WITH DISTINCT ' +
-            ' + '.join([f"labels({n})" for n in query_clauses['list_of_node_ids']]) +
-            ' AS all_labels'
-        )
-
-        if not return_preds:
-            label_clause += ', ' + ', '.join(query_clauses['list_of_node_ids'])
-        else:
-            label_clause += ', ' + ', '.join(return_preds)
-
-        unwind_label_clause = 'UNWIND all_labels AS label'
-
-        count_clause = []
-        if return_preds:
-            for index, predicate in enumerate(query_clauses['predicates']):
-                count_clause.append(f'WHEN label IN labels(startNode(r{index})) THEN startNode(r{index})')
-                count_clause.append(f'WHEN label IN labels(endNode(r{index})) THEN endNode(r{index})')
-        else:
-            for node_id in query_clauses['list_of_node_ids']:
-                count_clause.append(f'WHEN label IN labels({node_id}) THEN {node_id}')
-
-        count_clause = ' '.join(count_clause)
-        count_clause = f'WITH label, count(DISTINCT CASE {count_clause} ELSE null END) AS node_count'
-
-        node_count_by_label = 'WITH COLLECT({label: label, count: node_count}) AS nodes_count_by_label'
 
         if return_preds:
-            count_relationships = (
-            'WITH nodes_count_by_label, ' +
-            ' + '.join([f'COLLECT(DISTINCT r{i})' for i in range(len(query_clauses['predicates']))]) +
-            ' AS relationships'
-            )
-            unwind_relationships = 'UNWIND relationships AS rel'
-            count_edge_by_label = (
-            'WITH nodes_count_by_label, TYPE(rel) AS relationship_type, COUNT(rel) AS edge_count '
-            'WITH nodes_count_by_label, COLLECT(DISTINCT {relationship_type: relationship_type, count: edge_count}) AS edges_count_by_type'
-            )
-            return_clause = (
-            'RETURN nodes_count_by_label, edges_count_by_type'
-            )
-            label_count_query = f'''
-            {match_no_clause}
-            {where_no_clause}
-            {match_clause}
-            {where_clause}
-            {label_clause}
-            {unwind_label_clause}
-            {count_clause}
-            {node_count_by_label}
-            {match_no_clause}
-            {where_no_clause}
-            {match_clause}
-            {where_clause}
-            {count_relationships}
-            {unwind_relationships}
-            {count_edge_by_label}
-            {return_clause}
-            '''
+        # count query
+            count_clause = ''
+            for node in query_clauses['list_of_node_ids']:
+                count_clause += f"COUNT(DISTINCT {node}) AS {node}_{node_map[node]['type']}, "
+            for edge in query_clauses['predicates']:
+                edge_id = edge['predicate_id']
+                count_clause += f"COUNT(DISTINCT {edge_id}) AS {edge_id}_{predicate_map[edge_id]['type'].replace(' ', '_')}, "
+            return_clause = "RETURN " + count_clause.rstrip(', ')
+            label_count_query = f'''{match_no_clause} {where_no_clause} {match_clause} {where_clause} {return_clause}'''
         else:
-            count_edge_by_label = 'WITH nodes_count_by_label'
-            return_clause = (
-            'RETURN nodes_count_by_label'
-            )
-            label_count_query = f'''
-            {match_no_clause}
-            {where_no_clause}
-            {match_clause}
-            {where_clause}
-            {label_clause}
-            {unwind_label_clause}
-            {count_clause}
-            {node_count_by_label}
-            {match_no_clause}
-            {where_no_clause}
-            {match_clause}
-            {where_clause}
-            {count_edge_by_label}
-            {return_clause}
-            '''
+            count_clause = ''
+            for node in query_clauses['list_of_node_ids']:
+                count_clause += f"COUNT(DISTINCT {node}) AS {node}_{node_map[node]['type']}, "
+            return_clause = "RETURN " + count_clause.rstrip(', ')
+            label_count_query = f'''{match_no_clause} {where_no_clause} {return_clause}'''
 
         return [total_count, label_count_query]
 
@@ -449,22 +391,23 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             properties.append(f"{var_name}.{key} =~ '(?i){property}'")
         return properties
 
-    def parse_neo4j_results(self, results, all_properties):
-        (nodes, edges, _, _, meta_data) = self.process_result(results, all_properties)
+    def parse_neo4j_results(self, results, graph_components):
+        (nodes, edges, _, _, meta_data) = self.process_result(results, graph_components)
         return {"nodes": nodes, "edges": edges, "node_count": meta_data['node_count'], 
                 "edge_count": meta_data['edge_count'], "node_count_by_label": meta_data['node_count_by_label'], 
                 "edge_count_by_label": meta_data['edge_count_by_label']
                 }
 
-    def parse_and_serialize(self, input, schema, all_properties):
-        parsed_result = self.parse_neo4j_results(input, all_properties)
+    def parse_and_serialize(self, input, schema, graph_components):
+        parsed_result = self.parse_neo4j_results(input, graph_components)
         return parsed_result
 
-    def convert_to_dict(self, results, schema):
-        (_, _, node_dict, edge_dict, _) = self.process_result(results, True)
+    def convert_to_dict(self, results, schema, graph_components):
+        graph_components['properties'] = True
+        (_, _, node_dict, edge_dict, _) = self.process_result(results, graph_components)
         return (node_dict, edge_dict)
 
-    def process_result(self, results, all_properties):
+    def process_result(self, results,graph_components):
         match_result = results[0]
         node_count_by_label = []
         edge_count_by_label = []
@@ -502,7 +445,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                         }
 
                         for key, value in item.items():
-                            if all_properties:
+                            if graph_components['properties']:
                                 if key != "id" and key != "synonyms":
                                     node_data["data"][key] = value
                             else:
@@ -552,9 +495,38 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                 edge_count += count_record.get('total_edges', 0)
 
         if count_by_label:
+            # build edge type set
+            node_count_aggregate = {}
+            ege_count_aggregate = {}
+
+            # initialize node count aggreate dictionary where the key is the label.
+            for node in graph_components['nodes']:
+                node_type = node['type']
+                node_count_aggregate[node_type] = {'count': 0}
+
+            # initialize edge count aggreate dictionary where the key is the label.
+            for predicate in graph_components['predicates']:
+                edge_type = predicate['type'].replace(" ", "_").lower()
+                ege_count_aggregate[edge_type] = {'count': 0}
+
             for count_record in count_by_label:
-                node_count_by_label.extend(count_record.get('nodes_count_by_label', []))
-                edge_count_by_label.extend(count_record.get('edges_count_by_type', []))
+                # update node count aggregate dictionary with the count of each label
+                for key, value in count_record.items():
+                    node_type_key = '_'.join(key.split('_')[1:])
+                    if node_type_key in node_count_aggregate:
+                        node_count_aggregate[node_type_key]['count'] += value
+
+                # update edge count aggregate dictionary with the count of each label
+                for key, value in count_record.items():
+                    edge_type_key = '_'.join(key.split('_')[1:])
+                    if edge_type_key in ege_count_aggregate:
+                        ege_count_aggregate[edge_type_key]['count'] += value
+
+                # update the way node count by label and edge count by label are represented
+                for key, value in node_count_aggregate.items():
+                    node_count_by_label.append({'label': key, 'count': value['count']})
+                for key, value in ege_count_aggregate.items(): 
+                    edge_count_by_label.append({'label': key, 'count': value['count']})
 
         meta_data = {
             "node_count": node_count,


### PR DESCRIPTION
**Updated Count Operations**:
>    - Update the count logic to count individual neo4j variables 

**Count Aggregation Offloaded to Backend**:

> - Moved count aggregation logic from Neo4j queries to the backend server. 

> - Aggregation is based on labels so aggregating the count to find the count if node and edges using the label

     
 **Breaking Changes**:
     - **Predicate ID Requirement**:
  >  - The backend now requires a predicate_id for each predicate in the request payload.
  
  Fix #78 