### PR TITLE
Feature: Cancel Running Annotation and Group by Label

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ metta_data/
 venv
 .env
 public
+logs/

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,6 +12,7 @@ import os
 import logging
 import yaml
 from flask_redis import FlaskRedis
+from app.error import ThreadStopException
 
 app = Flask(__name__)
 socketio = SocketIO(app, cors_allowed_origins='*',
@@ -64,6 +65,7 @@ storage_service = StorageService()  # Initialize the storage service
 
 app.config['llm_handler'] = llm
 app.config['storage_service'] = storage_service
+app.config['annotation_threads'] = {}
 
 schema_manager = SchemaManager(schema_config_path='./config/schema_config.yaml',
                                biocypher_config_path='./config/biocypher_config.yaml')

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -13,6 +13,7 @@ import logging
 import yaml
 from flask_redis import FlaskRedis
 from app.error import ThreadStopException
+import threading
 
 app = Flask(__name__)
 socketio = SocketIO(app, cors_allowed_origins='*',
@@ -66,6 +67,7 @@ storage_service = StorageService()  # Initialize the storage service
 app.config['llm_handler'] = llm
 app.config['storage_service'] = storage_service
 app.config['annotation_threads'] = {}
+app.config['annotation_lock'] = threading.Lock()
 
 schema_manager = SchemaManager(schema_config_path='./config/schema_config.yaml',
                                biocypher_config_path='./config/biocypher_config.yaml')

--- a/app/error.py
+++ b/app/error.py
@@ -1,0 +1,3 @@
+class ThreadStopException(Exception):
+    def __init__(self, message):
+        super().__init__(message)

--- a/app/lib/graph.py
+++ b/app/lib/graph.py
@@ -11,7 +11,34 @@ class Graph:
         graph = self.collapse_nodes(graph)
         graph = self.group_into_parents(graph)
         return graph
-
+    def group_node_only(self, graph, request):
+        nodes = graph['nodes']
+        new_graph = {'nodes': [], 'edges': []}
+        
+        node_map_by_label = {}
+        
+        request_nodes = request['nodes']
+        
+        for node in request_nodes:
+            node_map_by_label[node['type']] = []
+            
+        for node in nodes:
+            if node['data']['type'] in node_map_by_label:
+                node_map_by_label[node['data']['type']].append(node)
+        
+        for node_type, nodes in node_map_by_label.items():
+            name = f"{len(nodes)} {node_type} nodes"
+            new_node = {
+                "data": {
+                    "id": generate(),
+                    "type": node_type,
+                    "name": name,
+                    "nodes": nodes
+                }
+            }
+            new_graph['nodes'].append(new_node)
+        return new_graph
+        
     def get_node_to_connections_map(self, graph):
         '''
         Build a mapping from node IDs to a dictionary of connections.

--- a/app/routes.py
+++ b/app/routes.py
@@ -586,7 +586,6 @@ def update_title(current_user_id, id):
         return jsonify({"error": str(e)}), 500
     
 @app.route('/annotation/delete', methods=['POST'])
-
 @token_required
 def delete_many(current_user_id):
     data = request.data.decode('utf-8').strip()  # Decode and strip the string of any extra spaces or quotes
@@ -616,6 +615,28 @@ def delete_many(current_user_id):
         
         response_data = {
             'message': f'Out of {len(annotation_ids)}, {delete_count} were successfully deleted.'
+        }
+        
+        formatted_response = json.dumps(response_data, indent=4)
+        return Response(formatted_response, mimetype='application/json')
+    except Exception as e:
+        logging.error('Error deleting annotations: {e}')
+        return jsonify({"error": str(e)}), 500
+    
+@app.route('/cancel/<id>', methods=['GET'])
+@token_required
+def cancel_annotation(current_user_id, id):
+    try:
+        annotation_threads = app.config['annotation_threads']
+        stop_event = annotation_threads.get(id, None)
+
+        if stop_event is None:
+            return jsonify({"error": "Annotation not found"}), 404
+  
+        stop_event.set()
+        
+        response_data = {
+            'message': f'Annotation {id} has been cancelled.'
         }
         
         formatted_response = json.dumps(response_data, indent=4)

--- a/app/routes.py
+++ b/app/routes.py
@@ -187,7 +187,10 @@ def process_query(current_user_id):
         answer = llm.generate_summary(result_graph, requests, question, False, summary)
 
         graph = Graph()
-        response = graph.group_graph(result_graph)
+        if len(result_graph['edges']) == 0:
+            response = graph.group_node_only(result_graph)
+        else:
+            response = graph.group_graph(result_graph)
         response['node_count'] = meta_data['node_count']
         response['edge_count'] = meta_data['edge_count']
         response['node_count_by_label'] = meta_data['node_count_by_label']
@@ -363,7 +366,10 @@ def get_by_id(current_user_id, id):
                 result, schema_manager.schema,
                 graph_components, result_type='graph')
             graph = Graph()
-            grouped_graph = graph.group_graph(response_data)
+            if (len(response_data['edges']) == 0):
+                response_data = graph.group_node_only(response_data)
+            else:
+                grouped_graph = graph.group_graph(response_data)
             response_data['nodes'] = grouped_graph['nodes']
             response_data['edges'] = grouped_graph['edges']
 

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -7,6 +7,7 @@ from neo4j import GraphDatabase
 import glob
 import os
 from neo4j.graph import Node, Relationship
+from app.error import ThreadStopException
 
 load_dotenv()
 
@@ -61,13 +62,15 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         logger.info(
             f"Finished loading {len(nodes_paths)} nodes and {len(edges_paths)} edges datasets.")
 
-    def run_query(self, query_code):
+    def run_query(self, query_code, stop_event=None):
         results = []
 
         # use lazy loading for improved performance
         with self.driver.session() as session:
             result = session.run(query_code)
             for record in result:
+                if stop_event.is_set():
+                    raise ThreadStopException('query runner is stopped')
                 results.append(record)
         return results
 


### PR DESCRIPTION
dd a feature to cancel a running annotation, which attempts to stop the process from continuing in any of the phases (graph result, total count, count by label, and summary), and clean up resources by deleting the annotation from MongoDB as well.
Add another grouping method that groups nodes by their labels if no edges are found for the nodes.