### PR TITLE
Handle missing nodes gracefully in Metta query generator

### DIFF
--- a/app/services/metta/metta_seralizer.py
+++ b/app/services/metta/metta_seralizer.py
@@ -12,12 +12,16 @@ def recurssive_seralize(metta_expression, result):
 
 def metta_seralizer(metta_result):
     result = []
+
+    if len(metta_result) == 0:
+        return []
+
     for node in metta_result:
         node = node.get_children()
         for metta_symbol in node:
             if isinstance(metta_symbol, SymbolAtom) and  metta_symbol.get_name() == ",":
                 continue
-            if isinstance(metta_symbol, ExpressionAtom):
+            elif isinstance(metta_symbol, ExpressionAtom):
                 res = recurssive_seralize(metta_symbol.get_children(), [])
                 result.append(tuple(res))
     return result

--- a/app/services/metta_generator.py
+++ b/app/services/metta_generator.py
@@ -256,12 +256,12 @@ class MeTTa_Query_Generator(QueryGeneratorInterface):
         count_by_label = {}
         nodes = []
         edges = []
-        node_to_dicts = {}
-        edge_to_dicts = {}
+        node_to_dict = {}
+        edge_to_dict = {}
         meta_data = {}
 
         if result_type == 'graph':
-            nodes, edges, node_to_dicts, edge_to_dicts = self.process_result_graph(
+            nodes, edges, node_to_dict, edge_to_dict = self.process_result_graph(
                     results[0], graph_components)
 
         if result_type == 'count':
@@ -274,7 +274,7 @@ class MeTTa_Query_Generator(QueryGeneratorInterface):
             meta_data = self.process_result_count(
                 node_and_edge_count, count_by_label, graph_components)
 
-        return (nodes, edges, node_to_dicts, edge_to_dicts, meta_data)
+        return (nodes, edges, node_to_dict, edge_to_dict, meta_data)
         
     def process_result_graph(self, results, graph_components):
         nodes = {}


### PR DESCRIPTION
* Updated the Metta query generator to return partial results when some nodes are missing instead of failing entirely to handle the calls from hypothesis generation 