### PR TITLE
chore: migrate CI integration test from Flask to FastAPI

### DIFF
--- a/.github/workflows/ci-staging-build-push.yml
+++ b/.github/workflows/ci-staging-build-push.yml
@@ -109,7 +109,7 @@ jobs:
               - "${{ env.APP_PORT }}:${{ env.APP_PORT }}"
             volumes:
               - .:/app   
-            command: flask run --host=0.0.0.0 --port=${{ env.APP_PORT }}
+            command: gunicorn app.main:socket_app --workers 1 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:${env.APP_PORT}
             restart: unless-stopped
             depends_on:
               - mongodb

--- a/.github/workflows/ci-staging-build-push.yml
+++ b/.github/workflows/ci-staging-build-push.yml
@@ -109,7 +109,7 @@ jobs:
               - "${{ env.APP_PORT }}:${{ env.APP_PORT }}"
             volumes:
               - .:/app   
-            command: gunicorn app.main:socket_app --workers 4 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:${{ env.APP_PORT }}
+            command: gunicorn app.main:socket_app --workers 1 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:${{ env.APP_PORT }}
             restart: unless-stopped
             depends_on:
               - mongodb
@@ -216,6 +216,7 @@ jobs:
         # Create test data directories
         mkdir -p /tmp/test_data
         mkdir -p /tmp/mork_data
+        mkdir -p /app/public
         touch /tmp/mork_data/annotation.act
         
         # Step 1: Start all services with docker compose up

--- a/.github/workflows/ci-staging-build-push.yml
+++ b/.github/workflows/ci-staging-build-push.yml
@@ -101,117 +101,117 @@ jobs:
         
         # Create docker-compose.ci.yml  
         cat > docker-compose.ci.yml << EOF
-services:
-  annotation_service:
-    image: $IMAGE_TAG
-    container_name: annotation_service-staging
-    ports:
-      - "${{ env.APP_PORT }}:${{ env.APP_PORT }}"
-    volumes:
-      - .:/app   
-    command: gunicorn app.main:socket_app --workers 1 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:${env.APP_PORT}
-    restart: unless-stopped
-    depends_on:
-      - mongodb
-      - redis
-    environment:
-      # Application
-      - APP_PORT=${{ env.APP_PORT }}
-      
-      # MongoDB - Local test container
-      - MONGO_URI=$MONGO_URI
-      
-      # Redis - Local test container
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - REDIS_URL=$REDIS_URL
-      - REDIS_EXPIRATION=$REDIS_EXPIRATION
-      
-      # Neo4j - ALL point to REAL external servers (safe for queries)
-      - NEO4J_URI=$NEO4J_URI
-      - NEO4J_USERNAME=$NEO4J_USERNAME
-      - NEO4J_PASSWORD=$NEO4J_PASSWORD
-      - HUMAN_NEO4J_URI=$HUMAN_NEO4J_URI
-      - HUMAN_NEO4J_USERNAME=$HUMAN_NEO4J_USERNAME
-      - HUMAN_NEO4J_PASSWORD=$HUMAN_NEO4J_PASSWORD
-      - FLY_NEO4J_URI=$FLY_NEO4J_URI
-      - FLY_NEO4J_USERNAME=$FLY_NEO4J_USERNAME
-      - FLY_NEO4J_PASSWORD=$FLY_NEO4J_PASSWORD
-      
-      # LLM
-      - LLM_MODEL=$LLM_MODEL
-      - GEMINI_API_KEY=$GEMINI_API_KEY
-      
-      # Security
-      - JWT_SECRET=$JWT_SECRET
-      - SECRET_KEY=$SECRET_KEY
-      
-      # Email
-      - MAIL_SERVER=$MAIL_SERVER
-      - MAIL_PORT=$MAIL_PORT
-      - MAIL_USERNAME=$MAIL_USERNAME
-      - MAIL_PASSWORD=$MAIL_PASSWORD
-      - MAIL_DEFAULT_SENDER=$MAIL_DEFAULT_SENDER
-      - MAIL_USE_TLS=$MAIL_USE_TLS
-      - MAIL_USE_SSL=$MAIL_USE_SSL
-      
-      # Monitoring
-      - SENTRY_DSN=$SENTRY_DSN
-      - AXIOM_TOKEN=$AXIOM_TOKEN
-      - AXIOM_DATASET=$AXIOM_DATASET
-      - AXIOM_PERFORMANCE_LOGS=$AXIOM_PERFORMANCE_LOGS
-      
-      # External Services
-      - MORK_URL=$MORK_URL
-      
-      # File Paths - Use temp directory
-      - PARENT_DIR=$PARENT_DIR
-      - MORK_DATA_DIR=/tmp/mork_data
-      
-      # Elasticsearch
-      - ES_URL=http://elasticsearch:9200
-      - ES_API_KEY=test_api_key
-      
-      # Docker
-      - DOCKER_HUB_REPO=$DOCKER_HUB_REPO
+        services:
+          annotation_service:
+            image: $IMAGE_TAG
+            container_name: annotation_service-staging
+            ports:
+              - "${{ env.APP_PORT }}:${{ env.APP_PORT }}"
+            volumes:
+              - .:/app   
+            command: gunicorn app.main:socket_app --workers 4 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:${{ env.APP_PORT }}
+            restart: unless-stopped
+            depends_on:
+              - mongodb
+              - redis
+            environment:
+              # Application
+              - APP_PORT=${{ env.APP_PORT }}
+              
+              # MongoDB - Local test container
+              - MONGO_URI=$MONGO_URI
+              
+              # Redis - Local test container
+              - REDIS_HOST=redis
+              - REDIS_PORT=6379
+              - REDIS_URL=$REDIS_URL
+              - REDIS_EXPIRATION=$REDIS_EXPIRATION
+              
+              # Neo4j - ALL point to REAL external servers (safe for queries)
+              - NEO4J_URI=$NEO4J_URI
+              - NEO4J_USERNAME=$NEO4J_USERNAME
+              - NEO4J_PASSWORD=$NEO4J_PASSWORD
+              - HUMAN_NEO4J_URI=$HUMAN_NEO4J_URI
+              - HUMAN_NEO4J_USERNAME=$HUMAN_NEO4J_USERNAME
+              - HUMAN_NEO4J_PASSWORD=$HUMAN_NEO4J_PASSWORD
+              - FLY_NEO4J_URI=$FLY_NEO4J_URI
+              - FLY_NEO4J_USERNAME=$FLY_NEO4J_USERNAME
+              - FLY_NEO4J_PASSWORD=$FLY_NEO4J_PASSWORD
+              
+              # LLM
+              - LLM_MODEL=$LLM_MODEL
+              - GEMINI_API_KEY=$GEMINI_API_KEY
+              
+              # Security
+              - JWT_SECRET=$JWT_SECRET
+              - SECRET_KEY=$SECRET_KEY
+              
+              # Email
+              - MAIL_SERVER=$MAIL_SERVER
+              - MAIL_PORT=$MAIL_PORT
+              - MAIL_USERNAME=$MAIL_USERNAME
+              - MAIL_PASSWORD=$MAIL_PASSWORD
+              - MAIL_DEFAULT_SENDER=$MAIL_DEFAULT_SENDER
+              - MAIL_USE_TLS=$MAIL_USE_TLS
+              - MAIL_USE_SSL=$MAIL_USE_SSL
+              
+              # Monitoring
+              - SENTRY_DSN=$SENTRY_DSN
+              - AXIOM_TOKEN=$AXIOM_TOKEN
+              - AXIOM_DATASET=$AXIOM_DATASET
+              - AXIOM_PERFORMANCE_LOGS=$AXIOM_PERFORMANCE_LOGS
+              
+              # External Services
+              - MORK_URL=$MORK_URL
+              
+              # File Paths - Use temp directory
+              - PARENT_DIR=$PARENT_DIR
+              - MORK_DATA_DIR=/tmp/mork_data
+              
+              # Elasticsearch
+              - ES_URL=http://elasticsearch:9200
+              - ES_API_KEY=test_api_key
+              
+              # Docker
+              - DOCKER_HUB_REPO=$DOCKER_HUB_REPO
 
-mongodb:
-  image: mongo:latest
-  container_name: mongodb-staging
-  volumes:
-    - mongo_data:/data/db
-  ports:
-    - "${{ env.MONGODB_DOCKER_PORT }}:27017"
-  restart: unless-stopped
+          mongodb:
+            image: mongo:latest
+            container_name: mongodb-staging
+            volumes:
+              - mongo_data:/data/db
+            ports:
+              - "${{ env.MONGODB_DOCKER_PORT }}:27017"
+            restart: unless-stopped
 
-redis:
-  image: redis:latest
-  container_name: redis-staging
-  volumes:
-    - redis_data:/data
-  ports:
-    - "6382:6379"
-  restart: unless-stopped
+          redis:
+            image: redis:latest
+            container_name: redis-staging
+            volumes:
+              - redis_data:/data
+            ports:
+              - "6382:6379"
+            restart: unless-stopped
 
-caddy:
-  image: caddy:latest
-  container_name: caddy-staging
-  ports:
-    - "${{ env.CADDY_PORT }}:${{ env.CADDY_PORT_FORWARD }}"
-  volumes:
-    - caddy_data:/data
-    - caddy_config:/config
-  command: caddy reverse-proxy --from http://0.0.0.0:${{ env.CADDY_PORT_FORWARD }} --to http://annotation_service:${{ env.APP_PORT }}
-  restart: unless-stopped
-  depends_on:
-    - annotation_service
+          caddy:
+            image: caddy:latest
+            container_name: caddy-staging
+            ports:
+              - "${{ env.CADDY_PORT }}:${{ env.CADDY_PORT_FORWARD }}"
+            volumes:
+              - caddy_data:/data
+              - caddy_config:/config
+            command: caddy reverse-proxy --from http://0.0.0.0:${{ env.CADDY_PORT_FORWARD }} --to http://annotation_service:${{ env.APP_PORT }}
+            restart: unless-stopped
+            depends_on:
+              - annotation_service
 
-volumes:
-  mongo_data:
-  redis_data:
-  caddy_data:
-  caddy_config:
-EOF
+        volumes:
+          mongo_data:
+          redis_data:
+          caddy_data:
+          caddy_config:
+        EOF
         
         # Create test data directories
         mkdir -p /tmp/test_data

--- a/.github/workflows/ci-staging-build-push.yml
+++ b/.github/workflows/ci-staging-build-push.yml
@@ -216,7 +216,6 @@ jobs:
         # Create test data directories
         mkdir -p /tmp/test_data
         mkdir -p /tmp/mork_data
-        mkdir -p /app/public
         touch /tmp/mork_data/annotation.act
         
         # Step 1: Start all services with docker compose up

--- a/.github/workflows/ci-staging-build-push.yml
+++ b/.github/workflows/ci-staging-build-push.yml
@@ -101,117 +101,117 @@ jobs:
         
         # Create docker-compose.ci.yml  
         cat > docker-compose.ci.yml << EOF
-        services:
-          annotation_service:
-            image: $IMAGE_TAG
-            container_name: annotation_service-staging
-            ports:
-              - "${{ env.APP_PORT }}:${{ env.APP_PORT }}"
-            volumes:
-              - .:/app   
-            command: gunicorn app.main:socket_app --workers 1 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:${env.APP_PORT}
-            restart: unless-stopped
-            depends_on:
-              - mongodb
-              - redis
-            environment:
-              # Application
-              - APP_PORT=${{ env.APP_PORT }}
-              
-              # MongoDB - Local test container
-              - MONGO_URI=$MONGO_URI
-              
-              # Redis - Local test container
-              - REDIS_HOST=redis
-              - REDIS_PORT=6379
-              - REDIS_URL=$REDIS_URL
-              - REDIS_EXPIRATION=$REDIS_EXPIRATION
-              
-              # Neo4j - ALL point to REAL external servers (safe for queries)
-              - NEO4J_URI=$NEO4J_URI
-              - NEO4J_USERNAME=$NEO4J_USERNAME
-              - NEO4J_PASSWORD=$NEO4J_PASSWORD
-              - HUMAN_NEO4J_URI=$HUMAN_NEO4J_URI
-              - HUMAN_NEO4J_USERNAME=$HUMAN_NEO4J_USERNAME
-              - HUMAN_NEO4J_PASSWORD=$HUMAN_NEO4J_PASSWORD
-              - FLY_NEO4J_URI=$FLY_NEO4J_URI
-              - FLY_NEO4J_USERNAME=$FLY_NEO4J_USERNAME
-              - FLY_NEO4J_PASSWORD=$FLY_NEO4J_PASSWORD
-              
-              # LLM
-              - LLM_MODEL=$LLM_MODEL
-              - GEMINI_API_KEY=$GEMINI_API_KEY
-              
-              # Security
-              - JWT_SECRET=$JWT_SECRET
-              - SECRET_KEY=$SECRET_KEY
-              
-              # Email
-              - MAIL_SERVER=$MAIL_SERVER
-              - MAIL_PORT=$MAIL_PORT
-              - MAIL_USERNAME=$MAIL_USERNAME
-              - MAIL_PASSWORD=$MAIL_PASSWORD
-              - MAIL_DEFAULT_SENDER=$MAIL_DEFAULT_SENDER
-              - MAIL_USE_TLS=$MAIL_USE_TLS
-              - MAIL_USE_SSL=$MAIL_USE_SSL
-              
-              # Monitoring
-              - SENTRY_DSN=$SENTRY_DSN
-              - AXIOM_TOKEN=$AXIOM_TOKEN
-              - AXIOM_DATASET=$AXIOM_DATASET
-              - AXIOM_PERFORMANCE_LOGS=$AXIOM_PERFORMANCE_LOGS
-              
-              # External Services
-              - MORK_URL=$MORK_URL
-              
-              # File Paths - Use temp directory
-              - PARENT_DIR=$PARENT_DIR
-              - MORK_DATA_DIR=/tmp/mork_data
-              
-              # Elasticsearch
-              - ES_URL=http://elasticsearch:9200
-              - ES_API_KEY=test_api_key
-              
-              # Docker
-              - DOCKER_HUB_REPO=$DOCKER_HUB_REPO
+services:
+  annotation_service:
+    image: $IMAGE_TAG
+    container_name: annotation_service-staging
+    ports:
+      - "${{ env.APP_PORT }}:${{ env.APP_PORT }}"
+    volumes:
+      - .:/app   
+    command: gunicorn app.main:socket_app --workers 1 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:${env.APP_PORT}
+    restart: unless-stopped
+    depends_on:
+      - mongodb
+      - redis
+    environment:
+      # Application
+      - APP_PORT=${{ env.APP_PORT }}
+      
+      # MongoDB - Local test container
+      - MONGO_URI=$MONGO_URI
+      
+      # Redis - Local test container
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_URL=$REDIS_URL
+      - REDIS_EXPIRATION=$REDIS_EXPIRATION
+      
+      # Neo4j - ALL point to REAL external servers (safe for queries)
+      - NEO4J_URI=$NEO4J_URI
+      - NEO4J_USERNAME=$NEO4J_USERNAME
+      - NEO4J_PASSWORD=$NEO4J_PASSWORD
+      - HUMAN_NEO4J_URI=$HUMAN_NEO4J_URI
+      - HUMAN_NEO4J_USERNAME=$HUMAN_NEO4J_USERNAME
+      - HUMAN_NEO4J_PASSWORD=$HUMAN_NEO4J_PASSWORD
+      - FLY_NEO4J_URI=$FLY_NEO4J_URI
+      - FLY_NEO4J_USERNAME=$FLY_NEO4J_USERNAME
+      - FLY_NEO4J_PASSWORD=$FLY_NEO4J_PASSWORD
+      
+      # LLM
+      - LLM_MODEL=$LLM_MODEL
+      - GEMINI_API_KEY=$GEMINI_API_KEY
+      
+      # Security
+      - JWT_SECRET=$JWT_SECRET
+      - SECRET_KEY=$SECRET_KEY
+      
+      # Email
+      - MAIL_SERVER=$MAIL_SERVER
+      - MAIL_PORT=$MAIL_PORT
+      - MAIL_USERNAME=$MAIL_USERNAME
+      - MAIL_PASSWORD=$MAIL_PASSWORD
+      - MAIL_DEFAULT_SENDER=$MAIL_DEFAULT_SENDER
+      - MAIL_USE_TLS=$MAIL_USE_TLS
+      - MAIL_USE_SSL=$MAIL_USE_SSL
+      
+      # Monitoring
+      - SENTRY_DSN=$SENTRY_DSN
+      - AXIOM_TOKEN=$AXIOM_TOKEN
+      - AXIOM_DATASET=$AXIOM_DATASET
+      - AXIOM_PERFORMANCE_LOGS=$AXIOM_PERFORMANCE_LOGS
+      
+      # External Services
+      - MORK_URL=$MORK_URL
+      
+      # File Paths - Use temp directory
+      - PARENT_DIR=$PARENT_DIR
+      - MORK_DATA_DIR=/tmp/mork_data
+      
+      # Elasticsearch
+      - ES_URL=http://elasticsearch:9200
+      - ES_API_KEY=test_api_key
+      
+      # Docker
+      - DOCKER_HUB_REPO=$DOCKER_HUB_REPO
 
-          mongodb:
-            image: mongo:latest
-            container_name: mongodb-staging
-            volumes:
-              - mongo_data:/data/db
-            ports:
-              - "${{ env.MONGODB_DOCKER_PORT }}:27017"
-            restart: unless-stopped
+mongodb:
+  image: mongo:latest
+  container_name: mongodb-staging
+  volumes:
+    - mongo_data:/data/db
+  ports:
+    - "${{ env.MONGODB_DOCKER_PORT }}:27017"
+  restart: unless-stopped
 
-          redis:
-            image: redis:latest
-            container_name: redis-staging
-            volumes:
-              - redis_data:/data
-            ports:
-              - "6382:6379"
-            restart: unless-stopped
+redis:
+  image: redis:latest
+  container_name: redis-staging
+  volumes:
+    - redis_data:/data
+  ports:
+    - "6382:6379"
+  restart: unless-stopped
 
-          caddy:
-            image: caddy:latest
-            container_name: caddy-staging
-            ports:
-              - "${{ env.CADDY_PORT }}:${{ env.CADDY_PORT_FORWARD }}"
-            volumes:
-              - caddy_data:/data
-              - caddy_config:/config
-            command: caddy reverse-proxy --from http://0.0.0.0:${{ env.CADDY_PORT_FORWARD }} --to http://annotation_service:${{ env.APP_PORT }}
-            restart: unless-stopped
-            depends_on:
-              - annotation_service
+caddy:
+  image: caddy:latest
+  container_name: caddy-staging
+  ports:
+    - "${{ env.CADDY_PORT }}:${{ env.CADDY_PORT_FORWARD }}"
+  volumes:
+    - caddy_data:/data
+    - caddy_config:/config
+  command: caddy reverse-proxy --from http://0.0.0.0:${{ env.CADDY_PORT_FORWARD }} --to http://annotation_service:${{ env.APP_PORT }}
+  restart: unless-stopped
+  depends_on:
+    - annotation_service
 
-        volumes:
-          mongo_data:
-          redis_data:
-          caddy_data:
-          caddy_config:
-        EOF
+volumes:
+  mongo_data:
+  redis_data:
+  caddy_data:
+  caddy_config:
+EOF
         
         # Create test data directories
         mkdir -p /tmp/test_data

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ public
 logs/
 Data/
 elastic-start-local
+.secrets
+docker-compose.ci.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN mkdir -p /app/public
+
 EXPOSE $APP_PORT
 
 CMD uvicorn app.main:socket_app --host 0.0.0.0 --port $APP_PORT

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-RUN mkdir -p /app/public
-
 EXPOSE $APP_PORT
 
 CMD uvicorn app.main:socket_app --host 0.0.0.0 --port $APP_PORT

--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -16,3 +16,8 @@ async def websocket_endpoint(websocket: WebSocket):
             await websocket.send_text(f"Message text was: {data}")
     except Exception as e:
         print(f"WebSocket error: {e}")
+
+
+@api_router.get("/health")
+def health():
+    return {"status": "ok"}

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 import json
 import socketio
@@ -13,7 +14,6 @@ from app.api.api_v1.api import api_router
 import app.events.socket_event
 from fastapi.staticfiles import StaticFiles
 import mimetypes
-
 # Add always on listen for socket events
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -90,5 +90,6 @@ app.include_router(api_router)
 mimetypes.add_type('application/octet-stream', '.tbi')
 mimetypes.add_type('application/gzip', '.gz')
 
+os.makedirs("public", exist_ok=True)
 app.mount("/public", StaticFiles(directory="public"), name="static")
 

--- a/app/main.py
+++ b/app/main.py
@@ -90,6 +90,9 @@ app.include_router(api_router)
 mimetypes.add_type('application/octet-stream', '.tbi')
 mimetypes.add_type('application/gzip', '.gz')
 
-os.makedirs("public", exist_ok=True)
-app.mount("/public", StaticFiles(directory="public"), name="static")
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+PUBLIC_DIR = os.path.join(BASE_DIR, "public")
+
+os.makedirs(PUBLIC_DIR, exist_ok=True)
+app.mount("/public", StaticFiles(directory=PUBLIC_DIR), name="static")
 

--- a/run_ci_local.sh
+++ b/run_ci_local.sh
@@ -2,7 +2,10 @@
 set -e
 
 # Load your secrets
-source .secrets
+if [ ! -r .secrets ]; then
+  echo "Error: .secrets file is missing or not readable. Create .secrets with the required environment variables before running this script." >&2
+  exit 1
+fi
 
 # Variables
 IMAGE_TAG="abdum1964/annotation:staging"
@@ -116,9 +119,21 @@ touch /tmp/mork_data/annotation.act
 # Step 4: Start
 echo "=== Starting services ==="
 docker compose -p annotation-staging -f docker-compose.ci.yml up -d
-sleep 30
 
+MAX_HEALTH_WAIT_SECONDS=60
+HEALTH_CHECK_INTERVAL_SECONDS=2
+HEALTH_ELAPSED_SECONDS=0
+until curl -fsS "http://localhost:${APP_PORT}/health" >/dev/null; do
+  if [ "$HEALTH_ELAPSED_SECONDS" -ge "$MAX_HEALTH_WAIT_SECONDS" ]; then
+    break
+  fi
+  sleep "$HEALTH_CHECK_INTERVAL_SECONDS"
+  HEALTH_ELAPSED_SECONDS=$((HEALTH_ELAPSED_SECONDS + HEALTH_CHECK_INTERVAL_SECONDS))
+done
 # Step 5: Check
 docker logs annotation_service-staging --tail 50
-curl -f http://localhost:${APP_PORT}/health && echo "HEALTH OK" || echo "HEALTH FAILED"
-
+if curl -fsS "http://localhost:${APP_PORT}/health" >/dev/null; then
+  echo "HEALTH OK"
+else
+  echo "HEALTH FAILED"
+fi

--- a/run_ci_local.sh
+++ b/run_ci_local.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+set -e
+
+# Load your secrets
+source .secrets
+
+# Variables
+IMAGE_TAG="abdum1964/annotation:staging"
+APP_PORT="5006"
+MONGODB_DOCKER_PORT="27021"
+CADDY_PORT="5557"
+CADDY_PORT_FORWARD="6001"
+MONGO_URI="mongodb://mongodb:27017/annotation"
+REDIS_URL="redis://redis:6379/0"
+REDIS_EXPIRATION="3600"
+PARENT_DIR="/tmp/test_data"
+LLM_MODEL="gemini"
+MAIL_USE_TLS="False"
+MAIL_USE_SSL="False"
+DOCKER_HUB_REPO="abdum1964/annotation"
+AXIOM_DATASET="application-logs"
+AXIOM_PERFORMANCE_LOGS="performance-metrics"
+
+# Step 1: Build
+echo "=== Building image ==="
+docker build --build-arg APP_PORT=$APP_PORT -t $IMAGE_TAG .
+
+# Step 2: Write compose file
+cat > docker-compose.ci.yml << EOF
+services:
+  annotation_service:
+    image: ${IMAGE_TAG}
+    container_name: annotation_service-staging
+    ports:
+      - "${APP_PORT}:${APP_PORT}"
+    volumes:
+      - .:/app
+    command: gunicorn app.main:socket_app --workers 1 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:${APP_PORT}
+    restart: unless-stopped
+    depends_on:
+      - mongodb
+      - redis
+    environment:
+      - APP_PORT=${APP_PORT}
+      - MONGO_URI=${MONGO_URI}
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_URL=${REDIS_URL}
+      - REDIS_EXPIRATION=${REDIS_EXPIRATION}
+      - NEO4J_URI=${NEO4J_URI}
+      - NEO4J_USERNAME=${NEO4J_USERNAME}
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD}
+      - HUMAN_NEO4J_URI=${HUMAN_NEO4J_URI}
+      - HUMAN_NEO4J_USERNAME=${HUMAN_NEO4J_USERNAME}
+      - HUMAN_NEO4J_PASSWORD=${HUMAN_NEO4J_PASSWORD}
+      - FLY_NEO4J_URI=${FLY_NEO4J_URI}
+      - FLY_NEO4J_USERNAME=${FLY_NEO4J_USERNAME}
+      - FLY_NEO4J_PASSWORD=${FLY_NEO4J_PASSWORD}
+      - LLM_MODEL=${LLM_MODEL}
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+      - JWT_SECRET=${JWT_SECRET}
+      - SECRET_KEY=${SECRET_KEY}
+      - MAIL_SERVER=${MAIL_SERVER}
+      - MAIL_PORT=${MAIL_PORT}
+      - MAIL_USERNAME=${MAIL_USERNAME}
+      - MAIL_PASSWORD=${MAIL_PASSWORD}
+      - MAIL_DEFAULT_SENDER=${MAIL_DEFAULT_SENDER}
+      - MAIL_USE_TLS=${MAIL_USE_TLS}
+      - MAIL_USE_SSL=${MAIL_USE_SSL}
+      - SENTRY_DSN=${SENTRY_DSN}
+      - AXIOM_TOKEN=${AXIOM_TOKEN}
+      - AXIOM_DATASET=${AXIOM_DATASET}
+      - AXIOM_PERFORMANCE_LOGS=${AXIOM_PERFORMANCE_LOGS}
+      - MORK_URL=${MORK_URL}
+      - PARENT_DIR=${PARENT_DIR}
+      - MORK_DATA_DIR=/tmp/mork_data
+      - ES_URL=http://elasticsearch:9200
+      - ES_API_KEY=test_api_key
+      - DOCKER_HUB_REPO=${DOCKER_HUB_REPO}
+
+  mongodb:
+    image: mongo:latest
+    container_name: mongodb-staging
+    ports:
+      - "${MONGODB_DOCKER_PORT}:27017"
+    restart: unless-stopped
+
+  redis:
+    image: redis:latest
+    container_name: redis-staging
+    ports:
+      - "6382:6379"
+    restart: unless-stopped
+
+  caddy:
+    image: caddy:latest
+    container_name: caddy-staging
+    ports:
+      - "${CADDY_PORT}:${CADDY_PORT_FORWARD}"
+    command: caddy reverse-proxy --from http://0.0.0.0:${CADDY_PORT_FORWARD} --to http://annotation_service:${APP_PORT}
+    restart: unless-stopped
+    depends_on:
+      - annotation_service
+
+volumes:
+  mongo_data:
+  redis_data:
+  caddy_data:
+  caddy_config:
+EOF
+
+# Step 3: Setup dirs
+mkdir -p /tmp/test_data /tmp/mork_data public
+touch /tmp/mork_data/annotation.act
+
+# Step 4: Start
+echo "=== Starting services ==="
+docker compose -p annotation-staging -f docker-compose.ci.yml up -d
+sleep 30
+
+# Step 5: Check
+docker logs annotation_service-staging --tail 50
+curl -f http://localhost:${APP_PORT}/health && echo "HEALTH OK" || echo "HEALTH FAILED"
+


### PR DESCRIPTION
## Summary
Migrated the CI/CD integration test to reflect the FastAPI migration, added local test script, and fixed static files directory creation.

## Changes
- Updated container startup command from `flask run` to `gunicorn` with uvicorn workers
- Added `run_ci_local.sh` script to run the integration test locally without pushing
- Fixed `RuntimeError: Directory 'public' does not exist` — `public/` is now created at runtime in `main.py` using `os.makedirs` instead of relying on the filesystem or Dockerfile
- Health check endpoints remain at `/health` (now served by FastAPI)

## How to Test
Run locally before pushing:
```bash
./run_ci_local.sh
```

## Related
- Part of Flask → FastAPI migration