### PR TITLE
fix: write MORK temp query files to /dev/shm instead of dataset dir

### DIFF
--- a/.github/workflows/ci-staging-build-push.yml
+++ b/.github/workflows/ci-staging-build-push.yml
@@ -230,6 +230,17 @@ jobs:
     - name: Validate Annotation Container (Integration Test)
       id: validate-container
       env:
+        # Neo4j - falls back to local container if secrets are not set
+        NEO4J_URI: ${{ secrets.NEO4J_URI || 'bolt://neo4j:7687' }}
+        NEO4J_USERNAME: ${{ secrets.NEO4J_USERNAME || 'neo4j' }}
+        NEO4J_PASSWORD: ${{ secrets.NEO4J_PASSWORD || 'testpassword' }}
+        HUMAN_NEO4J_URI: ${{ secrets.HUMAN_NEO4J_URI || 'bolt://neo4j:7687' }}
+        HUMAN_NEO4J_USERNAME: ${{ secrets.HUMAN_NEO4J_USERNAME || 'neo4j' }}
+        HUMAN_NEO4J_PASSWORD: ${{ secrets.HUMAN_NEO4J_PASSWORD || 'testpassword' }}
+        FLY_NEO4J_URI: ${{ secrets.FLY_NEO4J_URI || 'bolt://neo4j:7687' }}
+        FLY_NEO4J_USERNAME: ${{ secrets.FLY_NEO4J_USERNAME || 'neo4j' }}
+        FLY_NEO4J_PASSWORD: ${{ secrets.FLY_NEO4J_PASSWORD || 'testpassword' }}
+
         # Other environment variables
         MAIL_SERVER: ${{ secrets.MAIL_SERVER }}
         MAIL_PORT: ${{ secrets.MAIL_PORT }}
@@ -289,16 +300,16 @@ jobs:
               - REDIS_URL_BROKER=redis://redis:6379/1
               - REDIS_EXPIRATION=$REDIS_EXPIRATION
 
-              # Neo4j - Local test container
-              - NEO4J_URI=bolt://neo4j:7687
-              - NEO4J_USERNAME=neo4j
-              - NEO4J_PASSWORD=testpassword
-              - HUMAN_NEO4J_URI=bolt://neo4j:7687
-              - HUMAN_NEO4J_USERNAME=neo4j
-              - HUMAN_NEO4J_PASSWORD=testpassword
-              - FLY_NEO4J_URI=bolt://neo4j:7687
-              - FLY_NEO4J_USERNAME=neo4j
-              - FLY_NEO4J_PASSWORD=testpassword
+              # Neo4j - uses real secrets if available, otherwise falls back to local container
+              - NEO4J_URI=$NEO4J_URI
+              - NEO4J_USERNAME=$NEO4J_USERNAME
+              - NEO4J_PASSWORD=$NEO4J_PASSWORD
+              - HUMAN_NEO4J_URI=$HUMAN_NEO4J_URI
+              - HUMAN_NEO4J_USERNAME=$HUMAN_NEO4J_USERNAME
+              - HUMAN_NEO4J_PASSWORD=$HUMAN_NEO4J_PASSWORD
+              - FLY_NEO4J_URI=$FLY_NEO4J_URI
+              - FLY_NEO4J_USERNAME=$FLY_NEO4J_USERNAME
+              - FLY_NEO4J_PASSWORD=$FLY_NEO4J_PASSWORD
 
               # LLM
               - LLM_MODEL=$LLM_MODEL

--- a/.github/workflows/ci-staging-build-push.yml
+++ b/.github/workflows/ci-staging-build-push.yml
@@ -230,16 +230,6 @@ jobs:
     - name: Validate Annotation Container (Integration Test)
       id: validate-container
       env:
-        NEO4J_URI: ${{ secrets.NEO4J_URI }}
-        NEO4J_USERNAME: ${{ secrets.NEO4J_USERNAME }}
-        NEO4J_PASSWORD: ${{ secrets.NEO4J_PASSWORD }}
-        HUMAN_NEO4J_URI: ${{ secrets.HUMAN_NEO4J_URI }}
-        HUMAN_NEO4J_USERNAME: ${{ secrets.HUMAN_NEO4J_USERNAME }}
-        HUMAN_NEO4J_PASSWORD: ${{ secrets.HUMAN_NEO4J_PASSWORD }}
-        FLY_NEO4J_URI: ${{ secrets.FLY_NEO4J_URI }}
-        FLY_NEO4J_USERNAME: ${{ secrets.FLY_NEO4J_USERNAME }}
-        FLY_NEO4J_PASSWORD: ${{ secrets.FLY_NEO4J_PASSWORD }}
-        
         # Other environment variables
         MAIL_SERVER: ${{ secrets.MAIL_SERVER }}
         MAIL_PORT: ${{ secrets.MAIL_PORT }}
@@ -283,6 +273,7 @@ jobs:
             depends_on:
               - mongodb
               - redis
+              - neo4j
             environment:
               # Application
               - APP_PORT=${{ env.APP_PORT }}
@@ -298,16 +289,16 @@ jobs:
               - REDIS_URL_BROKER=redis://redis:6379/1
               - REDIS_EXPIRATION=$REDIS_EXPIRATION
 
-              # Neo4j - ALL point to REAL external servers (safe for queries)
-              - NEO4J_URI=$NEO4J_URI
-              - NEO4J_USERNAME=$NEO4J_USERNAME
-              - NEO4J_PASSWORD=$NEO4J_PASSWORD
-              - HUMAN_NEO4J_URI=$HUMAN_NEO4J_URI
-              - HUMAN_NEO4J_USERNAME=$HUMAN_NEO4J_USERNAME
-              - HUMAN_NEO4J_PASSWORD=$HUMAN_NEO4J_PASSWORD
-              - FLY_NEO4J_URI=$FLY_NEO4J_URI
-              - FLY_NEO4J_USERNAME=$FLY_NEO4J_USERNAME
-              - FLY_NEO4J_PASSWORD=$FLY_NEO4J_PASSWORD
+              # Neo4j - Local test container
+              - NEO4J_URI=bolt://neo4j:7687
+              - NEO4J_USERNAME=neo4j
+              - NEO4J_PASSWORD=testpassword
+              - HUMAN_NEO4J_URI=bolt://neo4j:7687
+              - HUMAN_NEO4J_USERNAME=neo4j
+              - HUMAN_NEO4J_PASSWORD=testpassword
+              - FLY_NEO4J_URI=bolt://neo4j:7687
+              - FLY_NEO4J_USERNAME=neo4j
+              - FLY_NEO4J_PASSWORD=testpassword
 
               # LLM
               - LLM_MODEL=$LLM_MODEL
@@ -353,6 +344,16 @@ jobs:
               - redis_data:/data
             ports:
               - "6382:6379"
+            restart: unless-stopped
+
+          neo4j:
+            image: neo4j:5.21
+            container_name: neo4j-staging
+            ports:
+              - "7474:7474"
+              - "7687:7687"
+            environment:
+              - NEO4J_AUTH=neo4j/testpassword
             restart: unless-stopped
 
           caddy:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -3,7 +3,7 @@ import secrets
 from typing import List, Optional
 
 import yaml
-from pydantic import AnyHttpUrl, field_validator
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
@@ -47,6 +47,13 @@ class Settings(BaseSettings):
         case_sensitive = True
         env_file = ".env"
         extra = "ignore"  # Allow extra env vars without validation error
+
+    @field_validator("MAIL_PORT", mode="before")
+    @classmethod
+    def parse_mail_port(cls, v):
+        if v == "" or v is None:
+            return None
+        return v
 
     @field_validator("DATABASE_TYPE", mode="before")
     @classmethod

--- a/app/services/mork_cli_generator.py
+++ b/app/services/mork_cli_generator.py
@@ -126,7 +126,8 @@ class MorkCLIQueryGenerator(MorkQueryGenerator):
         metta_query = f'(exec 0 (I (ACT {target_space} {pattern_str})) (, {template_str}))'
         query_file = Path("/dev/shm") / f"query_{uuid.uuid4().hex}.metta"
         try:
-            with open(query_file, "w") as f:
+            fd = os.open(query_file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(fd, "w") as f:
                 f.write(metta_query)
             session = _get_session(str(self.dataset_path))
             result = session.exec_query(str(query_file))
@@ -510,7 +511,8 @@ class MorkCLIQueryGenerator(MorkQueryGenerator):
         query_file = Path("/dev/shm") / f"query_{query_id}.metta"
 
         try:
-            with open(query_file, "w") as f:
+            fd = os.open(query_file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(fd, "w") as f:
                 f.write(metta_query)
 
 

--- a/app/services/mork_cli_generator.py
+++ b/app/services/mork_cli_generator.py
@@ -124,12 +124,12 @@ class MorkCLIQueryGenerator(MorkQueryGenerator):
                     logger.warning(f"SHM Symlink update failed: {e}")
 
         metta_query = f'(exec 0 (I (ACT {target_space} {pattern_str})) (, {template_str}))'
-        query_file = self.dataset_path / f"query_{uuid.uuid4().hex}.metta"
+        query_file = Path("/dev/shm") / f"query_{uuid.uuid4().hex}.metta"
         try:
             with open(query_file, "w") as f:
                 f.write(metta_query)
             session = _get_session(str(self.dataset_path))
-            result = session.exec_query(query_file.name)
+            result = session.exec_query(str(query_file))
             raw = result.stdout
             actual = raw.split("result:", 1)[1].strip() if "result:" in raw else raw.strip()
             return self.metta.parse_all(actual)
@@ -507,17 +507,16 @@ class MorkCLIQueryGenerator(MorkQueryGenerator):
             return self._resolve_chained_patterns(pattern_tuple, template_tuple, query, start_time)
         
         query_id = uuid.uuid4().hex
-        query_file_name = f"query_{query_id}.metta"
-        query_file = self.dataset_path / query_file_name
-        
+        query_file = Path("/dev/shm") / f"query_{query_id}.metta"
+
         try:
             with open(query_file, "w") as f:
                 f.write(metta_query)
-            
+
 
             try:
                 session = _get_session(str(self.dataset_path))
-                result = session.exec_query(query_file_name)
+                result = session.exec_query(str(query_file))
                 raw_output = result.stdout
             except subprocess.CalledProcessError as e:
                 logger.error(f"MORK exec error: {e.stderr}")


### PR DESCRIPTION
## Summary
- MORK query execution wrote temporary `.metta` files into the dataset directory (`metta_out_v6/`), which accumulated on process crashes since the `finally`-block cleanup only runs on clean exits
- Redirected both temp file write sites in `MorkCLIQueryGenerator` to `/dev/shm`, which is already volume-mounted into the MORK container
- Full path is now passed to `exec_query` instead of just the filename, since `/dev/shm` is not the container's working directory

## Test plan
- [ ] Run a query against the human dataset and confirm no `query_*.metta` files appear in `metta_out_v6/`
- [ ] Confirm query results are still correct
- [ ] Verify `/dev/shm/query_*.metta` files are created and cleaned up
      after each query
