### PR TITLE
fix: recover annotations stuck in PENDING after Celery worker restart

### DIFF
--- a/app/api/api_v1/endpoints/query.py
+++ b/app/api/api_v1/endpoints/query.py
@@ -380,6 +380,23 @@ def get_annotation_by_id(
                  response_data['status'] = TaskStatus.PENDING.value
                  from app.annotation_controller import requery
                  requery(annotation_id, query, json_request, species)
+        elif status == TaskStatus.PENDING.value:
+            # Recovery: graph was computed (e.g. before a worker restart) but
+            # summary_task never ran to flip the status to COMPLETE.
+            default_path = f"/app/public/graph/{id}.json"
+            resolved_path = file_path if (file_path and os.path.exists(file_path)) else (
+                default_path if os.path.exists(default_path) else None
+            )
+            if resolved_path:
+                AnnotationStorageService.update(
+                    annotation_id,
+                    {"status": TaskStatus.COMPLETE.value, "path_url": resolved_path},
+                )
+                response_data['status'] = TaskStatus.COMPLETE.value
+                with open(resolved_path, 'r') as f:
+                    graph = json.load(f)
+                response_data['nodes'] = graph.get('nodes')
+                response_data['edges'] = graph.get('edges')
         return response_data
 
     return response_data

--- a/app/workers/task_handler.py
+++ b/app/workers/task_handler.py
@@ -73,10 +73,11 @@ def check_for_cancellation(annotation_id):
     """
     Checks for the cancellation flag.
     If cancelled, raises an exception to abort the flow.
+    A missing Redis key (e.g. after a worker restart) is NOT treated as cancellation.
     """
     current_status = get_status(annotation_id)
 
-    if current_status is None or current_status == TaskStatus.CANCELLED.value:
+    if current_status == TaskStatus.CANCELLED.value:
         raise TaskCancelledException()
 
 
@@ -210,6 +211,9 @@ def summary_task(chord_results, annotation_id, request, all_status, summary=None
         redis_state.expire(f"annotation:{annotation_id}", 60)
     except TaskCancelledException as e:
         set_status(annotation_id, TaskStatus.CANCELLED.value)
+        AnnotationStorageService.update(
+            annotation_id, {"status": TaskStatus.CANCELLED.value}
+        )
         socket_event = {
             "status": TaskStatus.CANCELLED.value,
             "update": {"summary": "Summary cancelled"},


### PR DESCRIPTION
## Problem

When the Celery worker restarts while a chord is in flight, the three header tasks (graph_task, total_count_task, label_count_task) may complete and persist their results, but the chord callback (summary_task) is never re-queued by the new worker. This leaves annotations stuck in PENDING status in MongoDB indefinitely — the graph data is ready but never served.

Reproduced on annotation `6a0346633053c094af14bf8b`: all three tasks completed (graph file written, counts saved), but summary_task never ran after the worker restart at 10:47 on 2026-05-12.

## Root causes

**Bug 1 — false cancellation on missing Redis key**
`check_for_cancellation()` raised `TaskCancelledException` when `get_status()` returned `None`. After a worker restart, the ephemeral `annotation:{id}` key in Redis db=2 is gone, so the next call to `check_for_cancellation` inside `summary_task` treated the missing key as a user cancellation.

**Bug 2 — cancellation didn't persist to MongoDB**
The `except TaskCancelledException` handler in `summary_task` only called `set_status()` (Redis), never `AnnotationStorageService.update()`. So MongoDB stayed at PENDING even when Redis showed CANCELLED.

**Bug 3 — no recovery path in the GET endpoint**
`GET /annotation/{id}` returned PENDING forever when graph data was already on disk. There was no path to detect and recover this state.

## Changes

- **`app/workers/task_handler.py`**
  - `check_for_cancellation`: only raises on an explicit `CANCELLED` value; a `None` key (worker restart) is no longer treated as cancellation.
  - `summary_task` cancellation handler: added `AnnotationStorageService.update(...CANCELLED...)` so MongoDB stays in sync with Redis.

- **`app/api/api_v1/endpoints/query.py`**
  - `GET /annotation/{id}`: added recovery branch — when status is `PENDING` but the graph JSON file exists at `/app/public/graph/{id}.json`, the annotation is immediately marked `COMPLETE` and the graph is returned. Checks `path_url` first, falls back to the deterministic file path.

## Testing

- Verified that annotation `6a0346633053c094af14bf8b` (stuck since yesterday) returned `COMPLETE` with 327 nodes and 186 edges on the first GET after deploying this fix.
- New queries continue to complete normally via the existing chord flow.

## Known pre-existing issue (out of scope)

In `summary_task`, the `if summary is not None` branch (line ~142) references `meta_data` before it is assigned. This causes a `NameError` caught by `except Exception`, so the annotation completes but with the fallback summary instead of the cached one. Tracked separately.
