### PR TITLE
feat: surface detailed errors and query timing in annotation responses

### DIFF
--- a/app/api/api_v1/endpoints/query.py
+++ b/app/api/api_v1/endpoints/query.py
@@ -180,7 +180,7 @@ def process_query(
 
     except Exception as e:
         logger.error(f"Error processing query: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal Server Error")
+        raise HTTPException(status_code=500, detail=str(e))
 
 @router.post("/email-query/{id}")
 def process_email_query(
@@ -337,6 +337,10 @@ def get_annotation_by_id(
     species = cursor.species
     source = cursor.data_source
     files = cursor.files
+    retrieval_duration = cursor.retrieval_duration
+    processing_duration = cursor.processing_duration
+    total_duration = cursor.total_duration
+    error_message = cursor.error_message
 
     response_data = {
         "annotation_id": str(annotation_id),
@@ -351,9 +355,13 @@ def get_annotation_by_id(
     
     if summary: response_data["summary"] = summary
     if node_count: response_data["node_count"] = node_count; response_data["edge_count"] = edge_count
-    if node_count_by_label: 
+    if node_count_by_label:
         response_data["node_count_by_label"] = node_count_by_label
         response_data["edge_count_by_label"] = edge_count_by_label
+    if retrieval_duration: response_data["retrieval_duration"] = retrieval_duration
+    if processing_duration: response_data["processing_duration"] = processing_duration
+    if total_duration: response_data["total_duration"] = total_duration
+    if error_message: response_data["error_message"] = error_message
         
     if cursor.data_source == 'ai-assistant':
          return {"annotation_id": str(annotation_id), "question": question, "answer": answer}

--- a/app/models/annotation.py
+++ b/app/models/annotation.py
@@ -29,6 +29,7 @@ class Annotation(Schema):
     retrieval_duration = None
     processing_duration = None
     total_duration = None
+    error_message = None
 
     def __init__(self, **kwargs):
         self.schema = {
@@ -69,6 +70,7 @@ class Annotation(Schema):
             "retrieval_duration": Types.String,
             "processing_duration": Types.String,
             "total_duration": Types.String,
+            "error_message": {"type": Types.String},
             "species": {"type": Types.String, "required": True, "default": "human"},
             "data_source": any,
             "files": any,

--- a/app/workers/task_handler.py
+++ b/app/workers/task_handler.py
@@ -443,7 +443,7 @@ def graph_task(
         }
         redis_client.publish("socket_event", json.dumps(socket_event))
         AnnotationStorageService.update(
-            annotation_id, {"status": TaskStatus.FAILED.value}
+            annotation_id, {"status": TaskStatus.FAILED.value, "error_message": str(e)}
         )
         logger.error("Error generating result graph %s", e)
 
@@ -586,7 +586,7 @@ def total_count_task(
         update_task(annotation_id, "total_count", 0)
         AnnotationStorageService.update(
             annotation_id,
-            {"status": TaskStatus.FAILED.value, "node_count": 0, "edge_count": 0},
+            {"status": TaskStatus.FAILED.value, "node_count": 0, "edge_count": 0, "error_message": str(e)},
         )
         socket_event = {
             "status": TaskStatus.FAILED.value,
@@ -736,6 +736,7 @@ def label_count_task(
                 "status": TaskStatus.FAILED.value,
                 "node_count_by_label": update["node_count_by_label"],
                 "edge_count_by_label": update["edge_count_by_label"],
+                "error_message": str(e),
             },
         )
         socket_event = {


### PR DESCRIPTION
## Summary

- `GET /annotation/{id}` now returns `retrieval_duration`, `processing_duration`, and `total_duration` (already calculated and stored by Celery tasks but never exposed to callers).
- When an async task fails, the exception message is persisted to MongoDB as `error_message` and returned in the polling response so callers know *why* a query failed instead of only seeing `"status": "FAILED"`.
- `POST /query` now surfaces the real exception message in the `detail` field of 500 responses instead of the generic `"Internal Server Error"`.

## Changed files

| File | Change |
|------|--------|
| `app/models/annotation.py` | Add `error_message` attribute + schema field |
| `app/workers/task_handler.py` | Persist `error_message` on failure in `graph_task`, `total_count_task`, `label_count_task` |
| `app/api/api_v1/endpoints/query.py` | Read and return timing/error fields from cursor; expose real exception in POST handler |

## Response shape after this change

Successful query:
```json
{
  "annotation_id": "...",
  "status": "COMPLETE",
  "retrieval_duration": "2.35 sec",
  "processing_duration": "145 ms",
  "total_duration": "5.12 sec"
}
```

Failed query:

```json
{
  "annotation_id": "...",
  "status": "FAILED",
  "error_message": "Connection refused (host: neo4j, port: 7687)"
}
```

## Test plan
 - [ ] Submit a query, poll GET /annotation/{id} until COMPLETE — verify the three duration fields appear
 - [ ] Trigger a task failure, poll — verify error_message is populated and descriptive
 - [ ] Send a malformed POST /query — verify the 500 response detail contains the actual error, not "Internal Server Error"