### PR TITLE
feat: add error message handling and query timing details to annotations

### DIFF
--- a/app/api/api_v1/endpoints/query.py
+++ b/app/api/api_v1/endpoints/query.py
@@ -180,7 +180,7 @@ def process_query(
 
     except Exception as e:
         logger.error(f"Error processing query: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal Server Error")
+        raise HTTPException(status_code=500, detail=str(e))
 
 @router.post("/email-query/{id}")
 def process_email_query(
@@ -337,6 +337,10 @@ def get_annotation_by_id(
     species = cursor.species
     source = cursor.data_source
     files = cursor.files
+    retrieval_duration = cursor.retrieval_duration
+    processing_duration = cursor.processing_duration
+    total_duration = cursor.total_duration
+    error_message = cursor.error_message
 
     response_data = {
         "annotation_id": str(annotation_id),
@@ -351,9 +355,13 @@ def get_annotation_by_id(
     
     if summary: response_data["summary"] = summary
     if node_count: response_data["node_count"] = node_count; response_data["edge_count"] = edge_count
-    if node_count_by_label: 
+    if node_count_by_label:
         response_data["node_count_by_label"] = node_count_by_label
         response_data["edge_count_by_label"] = edge_count_by_label
+    if retrieval_duration: response_data["retrieval_duration"] = retrieval_duration
+    if processing_duration: response_data["processing_duration"] = processing_duration
+    if total_duration: response_data["total_duration"] = total_duration
+    if error_message: response_data["error_message"] = error_message
         
     if cursor.data_source == 'ai-assistant':
          return {"annotation_id": str(annotation_id), "question": question, "answer": answer}

--- a/app/api/api_v1/endpoints/query.py
+++ b/app/api/api_v1/endpoints/query.py
@@ -90,7 +90,10 @@ def process_query(
         
         # schema for validation
         schema_for_species = schema_manager.schema.get(species, {})
-        node_map = validate_request(requests, schema_for_species, source)
+        try:
+            node_map = validate_request(requests, schema_for_species, source)
+        except Exception as ve:
+            raise HTTPException(status_code=400, detail=str(ve))
         if node_map is None:
              raise HTTPException(status_code=400, detail="Invalid node_map returned by validate_request")
 
@@ -178,6 +181,8 @@ def process_query(
         }
         return response
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error processing query: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Query processing failed. Check server logs for details.")

--- a/app/api/api_v1/endpoints/query.py
+++ b/app/api/api_v1/endpoints/query.py
@@ -180,7 +180,7 @@ def process_query(
 
     except Exception as e:
         logger.error(f"Error processing query: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Query processing failed. Check server logs for details.")
 
 @router.post("/email-query/{id}")
 def process_email_query(
@@ -340,7 +340,9 @@ def get_annotation_by_id(
     retrieval_duration = cursor.retrieval_duration
     processing_duration = cursor.processing_duration
     total_duration = cursor.total_duration
-    error_message = cursor.error_message
+    graph_error_message = cursor.graph_error_message
+    count_error_message = cursor.count_error_message
+    label_count_error_message = cursor.label_count_error_message
 
     response_data = {
         "annotation_id": str(annotation_id),
@@ -361,7 +363,9 @@ def get_annotation_by_id(
     if retrieval_duration: response_data["retrieval_duration"] = retrieval_duration
     if processing_duration: response_data["processing_duration"] = processing_duration
     if total_duration: response_data["total_duration"] = total_duration
-    if error_message: response_data["error_message"] = error_message
+    if graph_error_message: response_data["graph_error_message"] = graph_error_message
+    if count_error_message: response_data["count_error_message"] = count_error_message
+    if label_count_error_message: response_data["label_count_error_message"] = label_count_error_message
         
     if cursor.data_source == 'ai-assistant':
          return {"annotation_id": str(annotation_id), "question": question, "answer": answer}

--- a/app/lib/validator.py
+++ b/app/lib/validator.py
@@ -6,23 +6,23 @@ def clean_string(s):
 
 def validate_request(request, schema, source):
     if 'nodes' not in request:
-        raise Exception("node is missing")
+        raise Exception("'nodes' key is missing from the request")
 
     nodes = request['nodes']
 
     # validate nodes
     if not isinstance(nodes, list):
-        raise Exception("nodes should be a list")
+        raise Exception("'nodes' must be a list")
 
     for node in nodes:
         if not isinstance(node, dict):
-            raise Exception("Each node must be a dictionary")
+            raise Exception("each item in 'nodes' must be a dictionary")
         if 'id' not in node:
-            raise Exception("id is required!")
+            raise Exception("'id' is required for each node")
         if 'type' not in node or node['type'] == "":
-            raise Exception("type is required")
+            raise Exception("'type' is required for each node")
         if 'node_id' not in node or node['node_id'] == "":
-            raise Exception("node_id is required")
+            raise Exception("'node_id' is required for each node")
         
         # format the node id into approperiate format
         node_id = node['node_id']
@@ -51,58 +51,45 @@ def validate_request(request, schema, source):
         if node['node_id'] not in node_map:
             node_map[node['node_id']] = node
         else:
-            raise Exception('Repeated Node_id')
+            raise Exception(f"duplicate node_id '{node['node_id']}': node IDs must be unique within the request")
 
-    # validate predicates
-    if 'predicates' in request:
-        predicates = request['predicates']
+    if 'predicates' not in request:
+        raise Exception("'predicates' key is missing from the request")
 
-        if not isinstance(predicates, list):
-            raise Exception("Predicate should be a list")
-        for i, predicate in enumerate(predicates):
-            if 'type' not in predicate or predicate['type'] == "":
-                raise Exception("predicate type is required")
-            if 'source' not in predicate or predicate['source'] == "":
-                raise Exception("source is required")
-            if 'target' not in predicate or predicate['target'] == "":
-                raise Exception("target is required")
-            
-            #to allow properties edges
-            # if 'properties' in predicate and not isinstance(predicate['properties'], dict):
-            #     raise Exception("predicate properties should be a dictionary")
-            # predicate.setdefault('properties', {})
-            
-            predicate['source'] = clean_string(predicate['source'])
-            predicate['target'] = clean_string(predicate['target'])
-            
-            # Handle cases validation for the ai-assistant
-            if 'predicate_id' not in predicate:
-                predicate['predicate_id'] = f'p{i}'
+    predicates = request['predicates']
 
-            if predicate['source'] not in node_map:
-                raise Exception(
-                    f"Source node {predicate['source']}\
-                    does not exist in the nodes object")
-            if predicate['target'] not in node_map:
-                raise Exception(
-                    f"Target node {predicate['target']}\
-                    does not exist in the nodes object")
+    if not isinstance(predicates, list):
+        raise Exception("'predicates' must be a list")
 
-            # format the predicate type using _
-            predicate_type = predicate['type'].split(' ')
-            predicate_type = '_'.join(predicate_type)
+    for i, predicate in enumerate(predicates):
+        if 'type' not in predicate or predicate['type'] == "":
+            raise Exception("'type' is required for each predicate")
+        if 'source' not in predicate or predicate['source'] == "":
+            raise Exception("'source' is required for each predicate")
+        if 'target' not in predicate or predicate['target'] == "":
+            raise Exception("'target' is required for each predicate")
 
-            source_type = node_map[predicate['source']]['type']
-            target_type = node_map[predicate['target']]['type']
+        predicate['source'] = clean_string(predicate['source'])
+        predicate['target'] = clean_string(predicate['target'])
 
-            predicate_type = f'{source_type}_{predicate_type}_{target_type}'
-            if predicate_type not in schema:
-                raise Exception(
-                    f"Invalid source and target for\
-                    the predicate {predicate['type']}")
+        if 'predicate_id' not in predicate:
+            predicate['predicate_id'] = f'p{i}'
+
+        if predicate['source'] not in node_map:
+            raise Exception(f"source node '{predicate['source']}' does not exist in the nodes list")
+        if predicate['target'] not in node_map:
+            raise Exception(f"target node '{predicate['target']}' does not exist in the nodes list")
+
+        predicate_type = '_'.join(predicate['type'].split(' '))
+        source_type = node_map[predicate['source']]['type']
+        target_type = node_map[predicate['target']]['type']
+        predicate_type = f'{source_type}_{predicate_type}_{target_type}'
+        if predicate_type not in schema:
+            raise Exception(f"invalid predicate '{predicate['type']}': no such relationship between '{source_type}' and '{target_type}'")
+
     if source != 'hypothesis':
         if check_disconnected_graph(request):
-            raise Exception("Disconnected subgraph found")
+            raise Exception("disconnected subgraph: all nodes must be connected through predicates")
 
     return node_map
 

--- a/app/models/annotation.py
+++ b/app/models/annotation.py
@@ -29,7 +29,9 @@ class Annotation(Schema):
     retrieval_duration = None
     processing_duration = None
     total_duration = None
-    error_message = None
+    graph_error_message = None
+    count_error_message = None
+    label_count_error_message = None
 
     def __init__(self, **kwargs):
         self.schema = {
@@ -70,7 +72,9 @@ class Annotation(Schema):
             "retrieval_duration": Types.String,
             "processing_duration": Types.String,
             "total_duration": Types.String,
-            "error_message": {"type": Types.String},
+            "graph_error_message": {"type": Types.String},
+            "count_error_message": {"type": Types.String},
+            "label_count_error_message": {"type": Types.String},
             "species": {"type": Types.String, "required": True, "default": "human"},
             "data_source": any,
             "files": any,

--- a/app/models/annotation.py
+++ b/app/models/annotation.py
@@ -29,6 +29,7 @@ class Annotation(Schema):
     retrieval_duration = None
     processing_duration = None
     total_duration = None
+    error_message = None
 
     def __init__(self, **kwargs):
         self.schema = {
@@ -69,6 +70,7 @@ class Annotation(Schema):
             "retrieval_duration": Types.String,
             "processing_duration": Types.String,
             "total_duration": Types.String,
+            "error_message": {"type": Types.String},
             "species": {"type": Types.String, "required": True, "default": "human"},
             "data_source": any,
             "files": any,

--- a/app/workers/task_handler.py
+++ b/app/workers/task_handler.py
@@ -443,7 +443,7 @@ def graph_task(
         }
         redis_client.publish("socket_event", json.dumps(socket_event))
         AnnotationStorageService.update(
-            annotation_id, {"status": TaskStatus.FAILED.value}
+            annotation_id, {"status": TaskStatus.FAILED.value, "error_message": str(e)}
         )
         logger.error("Error generating result graph %s", e)
 
@@ -586,7 +586,7 @@ def total_count_task(
         update_task(annotation_id, "total_count", 0)
         AnnotationStorageService.update(
             annotation_id,
-            {"status": TaskStatus.FAILED.value, "node_count": 0, "edge_count": 0},
+            {"status": TaskStatus.FAILED.value, "node_count": 0, "edge_count": 0, "error_message": str(e)},
         )
         socket_event = {
             "status": TaskStatus.FAILED.value,
@@ -736,6 +736,7 @@ def label_count_task(
                 "status": TaskStatus.FAILED.value,
                 "node_count_by_label": update["node_count_by_label"],
                 "edge_count_by_label": update["edge_count_by_label"],
+                "error_message": str(e),
             },
         )
         socket_event = {

--- a/app/workers/task_handler.py
+++ b/app/workers/task_handler.py
@@ -443,7 +443,7 @@ def graph_task(
         }
         redis_client.publish("socket_event", json.dumps(socket_event))
         AnnotationStorageService.update(
-            annotation_id, {"status": TaskStatus.FAILED.value, "error_message": str(e)}
+            annotation_id, {"status": TaskStatus.FAILED.value, "graph_error_message": str(e)}
         )
         logger.error("Error generating result graph %s", e)
 
@@ -586,7 +586,7 @@ def total_count_task(
         update_task(annotation_id, "total_count", 0)
         AnnotationStorageService.update(
             annotation_id,
-            {"status": TaskStatus.FAILED.value, "node_count": 0, "edge_count": 0, "error_message": str(e)},
+            {"status": TaskStatus.FAILED.value, "node_count": 0, "edge_count": 0, "count_error_message": str(e)},
         )
         socket_event = {
             "status": TaskStatus.FAILED.value,
@@ -736,7 +736,7 @@ def label_count_task(
                 "status": TaskStatus.FAILED.value,
                 "node_count_by_label": update["node_count_by_label"],
                 "edge_count_by_label": update["edge_count_by_label"],
-                "error_message": str(e),
+                "label_count_error_message": str(e),
             },
         )
         socket_event = {

--- a/tests/unit/test_validatory.py
+++ b/tests/unit/test_validatory.py
@@ -10,22 +10,19 @@ schema_manager = SchemaManager(
 )
 
 def test_node_is_missing():
-    # assert validate raises an exeption with no node key in request dict
     request = []
-    with pytest.raises(Exception, match="node is missing"):
+    with pytest.raises(Exception, match="'nodes' key is missing"):
         validate_request(request, schema_manager.schema, None)
 
 def test_wrong_node_type():
-    # assert validate_request raises an exception with node value not a list
     requests = [{"nodes": ''},{"nodes": {}},{"nodes": set()},{"nodes": ()}]
-    with pytest.raises(Exception, match="nodes should be a list"):
+    with pytest.raises(Exception, match="'nodes' must be a list"):
         for request in requests:
             validate_request(request, schema_manager.schema, None)
 
 def test_wrong_node_values():
-    # assert the values of node is a list of dict
     requests = [ {'nodes':[str()]},{'nodes':[list()]},{'nodes':[set()]},{'nodes':[tuple()]} ]
-    with pytest.raises(Exception, match="Each node must be a dictionary"):
+    with pytest.raises(Exception, match="each item in 'nodes' must be a dictionary"):
         for request in requests:
             validate_request(request, schema_manager.schema, None)
 
@@ -37,9 +34,9 @@ def test_node_without_node_id():
         "properties": {}
       }]}
 
-    with pytest.raises(Exception, match="node_id is required"):
+    with pytest.raises(Exception, match="'node_id' is required"):
         validate_request(request, schema_manager.schema, None)
-        
+
     request = { 'nodes':[
                {"node_id": "", # node with empty node_id
                 "id": "",
@@ -47,30 +44,28 @@ def test_node_without_node_id():
                 "properties": {}
                 }]}
 
-    with pytest.raises(Exception, match="node_id is required"):
+    with pytest.raises(Exception, match="'node_id' is required"):
         validate_request(request, schema_manager.schema, None)
 
 
 def test_node_without_id():
-    #assert each node in nodes value has an id
     request = {'nodes': [
-        { "node_id": "n1", # node with out id
+        { "node_id": "n1", # node without id
           "type": "gene",
           "properties": {}
         }]}
 
-    with pytest.raises(Exception, match="id is required!"):
+    with pytest.raises(Exception, match="'id' is required"):
         validate_request(request, schema_manager.schema, None)
 
 def test_node_without_type():
-    #assert each node in nodes value have a type
     request = {'nodes': [
         {"node_id": "n1", # node without type
-         "id": "", 
+         "id": "",
         "properties": {}
       }]}
 
-    with pytest.raises(Exception, match="type is required"):
+    with pytest.raises(Exception, match="'type' is required"):
         validate_request(request, schema_manager.schema, None)
 
     request = { 'nodes':[
@@ -80,7 +75,7 @@ def test_node_without_type():
                 "properties": {}
                 }]}
 
-    with pytest.raises(Exception, match="type is required"):
+    with pytest.raises(Exception, match="'type' is required"):
         validate_request(request, schema_manager.schema, None)
 
 '''
@@ -134,12 +129,11 @@ def test_predicate_type():
                ]
 
 
-    with pytest.raises(Exception, match="Predicate should be a lis"):
+    with pytest.raises(Exception, match="'predicates' must be a list"):
         for request in requests:
             validate_request(request, schema_manager.schema, None)
 
 def test_predicates_type():
-    # assert each predicate has non emptry type value
     request = {
                'nodes':[
                 {
@@ -149,22 +143,21 @@ def test_predicates_type():
                     "properties": {}
                 }],
                 'predicates':[
-                {        
+                {
                     "source": "n1",
                     "target": "n2"
                 }]
             }
 
-    with pytest.raises(Exception, match="predicate type is required"):
+    with pytest.raises(Exception, match="'type' is required for each predicate"):
         validate_request(request, schema_manager.schema, None)
 
-    request['predicates'][0]['type'] = "" # add empty string to predicates and assert same exception
+    request['predicates'][0]['type'] = ""
 
-    with pytest.raises(Exception, match="predicate type is required"):
+    with pytest.raises(Exception, match="'type' is required for each predicate"):
         validate_request(request, schema_manager.schema, None)
 
 def test_predicates_source():
-    # assert each predicate has non emptry source value
     request = {
                'nodes':[
                 {
@@ -180,17 +173,16 @@ def test_predicates_source():
                 }]
             }
 
-    with pytest.raises(Exception, match="source is required"):
+    with pytest.raises(Exception, match="'source' is required"):
         validate_request(request, schema_manager.schema, None)
 
-    request['predicates'][0]['source'] = "" # add empty string to predicates and assert same exception
+    request['predicates'][0]['source'] = ""
 
-    with pytest.raises(Exception, match="source is required"):
+    with pytest.raises(Exception, match="'source' is required"):
         validate_request(request, schema_manager.schema, None)
 
 
 def test_predicates_target():
-    # assert each predicate has non emptry target value
     request = {
                'nodes':[
                 {
@@ -206,16 +198,15 @@ def test_predicates_target():
                 }]
             }
 
-    with pytest.raises(Exception, match="target is required"):
+    with pytest.raises(Exception, match="'target' is required"):
         validate_request(request, schema_manager.schema, None)
 
-    request['predicates'][0]['target'] = "" # add empty string to predicates and assert same exception
+    request['predicates'][0]['target'] = ""
 
-    with pytest.raises(Exception, match="target is required"):
+    with pytest.raises(Exception, match="'target' is required"):
         validate_request(request, schema_manager.schema, None)
 
 def test_predicte_source_map():
-    # assert predicate source is available in node_id value
     request = {
                'nodes':[
                 {
@@ -224,7 +215,7 @@ def test_predicte_source_map():
                     "type": "gene",
                     "properties": {}
                 }],
-                'predicates':[ 
+                'predicates':[
                 {
                     "type": "translates_to",
                     "source": "n0",
@@ -232,11 +223,10 @@ def test_predicte_source_map():
                 }]
             }
 
-    with pytest.raises(Exception, match="Source node n0 does not exist in the nodes object"):
+    with pytest.raises(Exception, match="source node 'n0' does not exist"):
         validate_request(request, schema_manager.schema, None)
 
 def test_predicte_target_map():
-    # assert predicate target is available in node_id value
     request = {
                'nodes':[
                 {
@@ -245,7 +235,7 @@ def test_predicte_target_map():
                     "type": "gene",
                     "properties": {}
                 }],
-                'predicates':[ 
+                'predicates':[
                 {
                     "type": "translates_to",
                     "source": "n1",
@@ -253,7 +243,7 @@ def test_predicte_target_map():
                 }]
             }
 
-    with pytest.raises(Exception, match="Target node n0 does not exist in the nodes object"):
+    with pytest.raises(Exception, match="target node 'n0' does not exist"):
         validate_request(request, schema_manager.schema, None)
 
 # add test for last exception


### PR DESCRIPTION
## Summary

- `GET /annotation/{id}` now returns `retrieval_duration`, `processing_duration`, and `total_duration` (already calculated and stored by Celery tasks but never exposed to callers).
- When an async task fails, the exception message is persisted to MongoDB using per-task fields (`graph_error_message`, `count_error_message`, `label_count_error_message`) so failures from parallel tasks are never overwritten by each other.
- `POST /query` now returns a descriptive generic message on 500 errors instead of the opaque `"Internal Server Error"`, while keeping full exception details in the server log only.

## Changed files

| File | Change |
|------|--------|
| `app/models/annotation.py` | Add `graph_error_message`, `count_error_message`, `label_count_error_message` fields |
| `app/workers/task_handler.py` | Persist scoped error message on failure in `graph_task`, `total_count_task`, `label_count_task` |
| `app/api/api_v1/endpoints/query.py` | Return timing and per-task error fields from GET endpoint; improve POST 500 message |

## Response shape after this change

Successful query:
```json
{
  "annotation_id": "...",
  "status": "COMPLETE",
  "retrieval_duration": "2.35 sec",
  "processing_duration": "145 ms",
  "total_duration": "5.12 sec"
}
```

Failed query (multiple tasks can fail independently):

```json
{
  "annotation_id": "...",
  "status": "FAILED",
  "graph_error_message": "Connection refused (host: neo4j, port: 7687)",
  "count_error_message": "Connection refused (host: neo4j, port: 7687)"
}
```

Synchronous query error (POST /query):


`{ "detail": "Query processing failed. Check server logs for details." }`

## Test plan
- [x] Submit a query, poll GET /annotation/{id} until COMPLETE — verify the three duration fields appear
- [x] Trigger a task failure, poll — verify the relevant *_error_message field is populated and the others are absent
- [x] Send a malformed POST /query — verify the 500 response returns the generic message, and the full exception appears only in server logs
