### PR TITLE
fix: repair broken test suite and CI pipeline for main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Start Redis
         run: |
-          docker run --name redis -p 6379:6379 -d redis:latest
+          docker run --name redis -p 6379:6379 -d redis:7.2
           sleep 3
 
       - name: Run tests with pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,27 @@ jobs:
           docker run --name mongodb -p 27017:27017 -d mongo:latest
           sleep 5
 
-      - name: Run tests with pytest
+      - name: Start Redis
         run: |
+          docker run --name redis -p 6379:6379 -d redis:latest
+          sleep 3
+
+      - name: Run tests with pytest
+        env:
+          MONGO_URI: mongodb://localhost:27017/test
+          REDIS_URL: redis://localhost:6379/0
+          JWT_SECRET: test-jwt-secret
+          SECRET_KEY: test-secret-key
+          LLM_MODEL: gemini
+          GEMINI_API_KEY: dummy-key-for-testing
+          MAIL_SERVER: localhost
+          MAIL_PORT: 1025
+          MAIL_USERNAME: test
+          MAIL_PASSWORD: test
+          MAIL_DEFAULT_SENDER: test@example.com
+          MAIL_USE_TLS: "false"
+          MAIL_USE_SSL: "false"
+          PARENT_DIR: /tmp/test_data
+        run: |
+          mkdir -p /tmp/test_data
           pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
-from app import app
+from app.main import app
+from starlette.testclient import TestClient
 from app.services.schema_data import SchemaManager
 import time
 
@@ -26,7 +27,7 @@ def wait_for_db_connection():
 # Initializes a test client
 @pytest.fixture
 def client():
-    with app.test_client() as client:
+    with TestClient(app) as client:
         yield client  # Provides the test client for use in tests
 
 # List of nodes

--- a/tests/integration/test_response.py
+++ b/tests/integration/test_response.py
@@ -1,4 +1,3 @@
-import json
 from tests.lib.header_generator import generate_headers
 
 # test for the /relations/<node>
@@ -10,10 +9,10 @@ def test_node_relations(client, node_list):
         response = client.get(f'/relations/{node}', headers=headers)
 
         # assert url returned an HTTP 200 OK code
-        assert '200 OK' == response._status
+        assert response.status_code == 200
 
-        # decode return and parse to a dict object
-        schemas = json.loads(response.data.decode('utf-8'))
+        # parse response to a list of dicts
+        schemas = response.json()
         for schema in schemas:
             # assert that each return has the value of the node
             assert node in schema.values()
@@ -25,10 +24,10 @@ def test_edge_route(client):
     response = client.get('/edges', headers=headers)
 
     # check the return status
-    assert '200 OK' == response._status
+    assert response.status_code == 200
 
-    # decode return and parse to a dict object
-    schemas = json.loads(response.data.decode('utf-8'))
+    # parse response
+    schemas = response.json()
     for schema in schemas:
         # assert that each item has child and parent edges
         assert ('child_edges', 'parent_edge') == tuple(schema.keys())
@@ -40,10 +39,10 @@ def test_node_route(client):
     response = client.get('/nodes', headers=headers)
 
     # check the return status
-    assert '200 OK' == response._status
+    assert response.status_code == 200
 
-    # decode return and parse to a dict object
-    schemas = json.loads(response.data.decode('utf-8'))
+    # parse response
+    schemas = response.json()
     for schema in schemas:
         # assert that each item has child and parent nodes
         assert ('child_nodes', 'parent_node') == tuple(schema.keys())
@@ -51,13 +50,14 @@ def test_node_route(client):
 # test for empty json /query route
 def test_query_without_data(client):
     headers = generate_headers()
-    # make a call to the /query endpoint with out json data
+    # make a call to the /query endpoint without json data
+    # FastAPI returns 422 Unprocessable Entity when required body is missing
     response = client.post('/query', headers=headers)
-    assert response._status == '415 UNSUPPORTED MEDIA TYPE'
+    assert response.status_code == 422
 
 def test_query_with_empty_data(client):
-    headers=generate_headers()
+    headers = generate_headers()
     # make a call to the /query endpoint with empty json data
-    response = client.post('/query', data=json.dumps({'request': 'test'}), headers=headers, content_type='application/json')
-    assert response._status == '400 BAD REQUEST'
+    response = client.post('/query', json={'request': 'test'}, headers=headers)
+    assert response.status_code == 400
 

--- a/tests/unit/test_validatory.py
+++ b/tests/unit/test_validatory.py
@@ -13,21 +13,21 @@ def test_node_is_missing():
     # assert validate raises an exeption with no node key in request dict
     request = []
     with pytest.raises(Exception, match="node is missing"):
-        validate_request(request, schema_manager.schema)
+        validate_request(request, schema_manager.schema, None)
 
 def test_wrong_node_type():
     # assert validate_request raises an exception with node value not a list
     requests = [{"nodes": ''},{"nodes": {}},{"nodes": set()},{"nodes": ()}]
     with pytest.raises(Exception, match="nodes should be a list"):
         for request in requests:
-            validate_request(request, schema_manager.schema)
+            validate_request(request, schema_manager.schema, None)
 
 def test_wrong_node_values():
     # assert the values of node is a list of dict
     requests = [ {'nodes':[str()]},{'nodes':[list()]},{'nodes':[set()]},{'nodes':[tuple()]} ]
     with pytest.raises(Exception, match="Each node must be a dictionary"):
         for request in requests:
-            validate_request(request, schema_manager.schema)
+            validate_request(request, schema_manager.schema, None)
 
 def test_node_without_node_id():
     #assert each node in nodes value have a node_id
@@ -38,7 +38,7 @@ def test_node_without_node_id():
       }]}
 
     with pytest.raises(Exception, match="node_id is required"):
-        validate_request(request, schema_manager.schema)
+        validate_request(request, schema_manager.schema, None)
         
     request = { 'nodes':[
                {"node_id": "", # node with empty node_id
@@ -48,7 +48,7 @@ def test_node_without_node_id():
                 }]}
 
     with pytest.raises(Exception, match="node_id is required"):
-        validate_request(request, schema_manager.schema)
+        validate_request(request, schema_manager.schema, None)
 
 
 def test_node_without_id():
@@ -60,7 +60,7 @@ def test_node_without_id():
         }]}
 
     with pytest.raises(Exception, match="id is required!"):
-        validate_request(request, schema_manager.schema)
+        validate_request(request, schema_manager.schema, None)
 
 def test_node_without_type():
     #assert each node in nodes value have a type
@@ -71,7 +71,7 @@ def test_node_without_type():
       }]}
 
     with pytest.raises(Exception, match="type is required"):
-        validate_request(request, schema_manager.schema)
+        validate_request(request, schema_manager.schema, None)
 
     request = { 'nodes':[
                {"node_id": "", # node with empty type
@@ -81,7 +81,7 @@ def test_node_without_type():
                 }]}
 
     with pytest.raises(Exception, match="type is required"):
-        validate_request(request, schema_manager.schema)
+        validate_request(request, schema_manager.schema, None)
 
 '''
 def test_properties_key():
@@ -97,7 +97,7 @@ def test_properties_key():
     ]}
 
     with pytest.raises(Exception, match="protein_nam doesn't exsist in the schema!"):
-        validate_request(request, schema_manager.schema)
+        validate_request(request, schema_manager.schema, None)
 '''
 
 def test_predicate_type():
@@ -136,7 +136,7 @@ def test_predicate_type():
 
     with pytest.raises(Exception, match="Predicate should be a lis"):
         for request in requests:
-            validate_request(request, schema_manager.schema)
+            validate_request(request, schema_manager.schema, None)
 
 def test_predicates_type():
     # assert each predicate has non emptry type value
@@ -156,12 +156,12 @@ def test_predicates_type():
             }
 
     with pytest.raises(Exception, match="predicate type is required"):
-        validate_request(request, schema_manager.schema)
+        validate_request(request, schema_manager.schema, None)
 
     request['predicates'][0]['type'] = "" # add empty string to predicates and assert same exception
 
     with pytest.raises(Exception, match="predicate type is required"):
-        validate_request(request, schema_manager.schema)
+        validate_request(request, schema_manager.schema, None)
 
 def test_predicates_source():
     # assert each predicate has non emptry source value
@@ -181,12 +181,12 @@ def test_predicates_source():
             }
 
     with pytest.raises(Exception, match="source is required"):
-        validate_request(request, schema_manager.schema)
+        validate_request(request, schema_manager.schema, None)
 
     request['predicates'][0]['source'] = "" # add empty string to predicates and assert same exception
 
     with pytest.raises(Exception, match="source is required"):
-        validate_request(request, schema_manager.schema)
+        validate_request(request, schema_manager.schema, None)
 
 
 def test_predicates_target():
@@ -207,12 +207,12 @@ def test_predicates_target():
             }
 
     with pytest.raises(Exception, match="target is required"):
-        validate_request(request, schema_manager.schema)
+        validate_request(request, schema_manager.schema, None)
 
     request['predicates'][0]['target'] = "" # add empty string to predicates and assert same exception
 
     with pytest.raises(Exception, match="target is required"):
-        validate_request(request, schema_manager.schema)
+        validate_request(request, schema_manager.schema, None)
 
 def test_predicte_source_map():
     # assert predicate source is available in node_id value
@@ -233,7 +233,7 @@ def test_predicte_source_map():
             }
 
     with pytest.raises(Exception, match="Source node n0 does not exist in the nodes object"):
-        validate_request(request, schema_manager.schema)
+        validate_request(request, schema_manager.schema, None)
 
 def test_predicte_target_map():
     # assert predicate target is available in node_id value
@@ -254,7 +254,7 @@ def test_predicte_target_map():
             }
 
     with pytest.raises(Exception, match="Target node n0 does not exist in the nodes object"):
-        validate_request(request, schema_manager.schema)
+        validate_request(request, schema_manager.schema, None)
 
 # add test for last exception
 def test_predicate_schema_type():

--- a/tests/unit/test_validatory.py
+++ b/tests/unit/test_validatory.py
@@ -1,6 +1,13 @@
 import pytest
-from app.lib.validator import validate_request 
-from app import schema_manager
+from app.lib.validator import validate_request
+from app.services.schema_data import SchemaManager
+
+schema_manager = SchemaManager(
+    human_schema_config_path='./config/human_schema/human_full_schema_config.yaml',
+    biocypher_config_path='./config/biocypher_config.yaml',
+    human_datasources_config_path='./config/human_schema/data_source_schemas',
+    fly_schema_config_path='./config/fly_base_schema/dmel_full_schema_config.yaml',
+)
 
 def test_node_is_missing():
     # assert validate raises an exeption with no node key in request dict


### PR DESCRIPTION
## Summary

The `main.yml` CI pipeline has been failing since the app was migrated from
Flask to FastAPI. Three separate issues caused every `pytest` run to exit
with a collection error before any test could execute:

- `tests/conftest.py` imported `app` from the wrong location and used Flask's `test_client()` which does not exist in FastAPI
- `tests/unit/test_validatory.py` imported `schema_manager` from `app/__init__.py` where it was never defined
- `tests/integration/test_response.py` used Flask response attributes (`._status`, `.data`) that do not exist in starlette's `TestClient`
- `main.yml` relied entirely on repo secrets for test env vars; when those secrets are absent the app raises `ValueError: MONGO_URI is required` on import, blocking collection entirely

## Changes

| File | Fix |
|------|-----|
| `.github/workflows/main.yml` | Added Redis startup step; added hardcoded test env vars to pytest step (same pattern staging CI already uses) |
| `tests/conftest.py` | `from app import app` → `from app.main import app`; `app.test_client()` → `starlette.testclient.TestClient(app)` |
| `tests/unit/test_validatory.py` | Replaced `from app import schema_manager` with a local `SchemaManager` instantiation |
| `tests/integration/test_response.py` | `response._status` → `response.status_code`; `response.data` → `response.json()`; `data=json.dumps(...)` → `json=...`; 415 assertion → 422 (FastAPI's validation error code) |


