### PR TITLE
feat: MORK CLI optimizations — explosion caps, dual queues, and admission control

### DIFF
--- a/Data/graph_info.json
+++ b/Data/graph_info.json
@@ -1,9 +1,10 @@
 {
-  "node_count": 54573341,
-  "edge_count": 592423423,
-  "last_updated_at": "2026-04-27T07:17:26.276699Z",
-  "dataset_count": 24,
-  "data_size": "132.29 GB",
+  "node_count": 60574473,
+  "edge_count": 638002294,
+  "dataset_count": 36,
+  "last_updated_at": "2026-05-08",
+  "kg_format": "metta",
+  "data_size": "130.48 GB",
   "top_entities": [
     {
       "name": "snp",

--- a/app/annotation_controller.py
+++ b/app/annotation_controller.py
@@ -3,7 +3,7 @@ import json
 import os
 import datetime
 from app.api.deps import get_db_instance, get_schema_manager
-from app.workers.task_handler import graph_task, start_thread, reset_task, reset_status
+from app.workers.task_handler import graph_task, start_thread, reset_task, reset_status, _is_slow_query
 from app.lib import convert_to_csv, generate_file_path, \
     adjust_file_path
 import time
@@ -184,13 +184,11 @@ def requery(annotation_id, query, request, species='human'):
     # graph_task signature: (query_code, annotation_id, requests, result_status, species, status=None)
     # result_status argument is legacy (was event), passing 0 or None
     try:
-        graph_task.delay(
-            query, 
-            annotation_id, 
-            request, 
-            0, # dummy for 'result_status'
-            species, 
-            status=TaskStatus.COMPLETE.value
+        queue = 'slow' if _is_slow_query(request) else 'fast'
+        graph_task.apply_async(
+            args=[query, annotation_id, request, 0, species],
+            kwargs={'status': TaskStatus.COMPLETE.value},
+            queue=queue,
         )
     except Exception as e:
         logger.error("Error triggering graph_task celery job %s", e)

--- a/app/annotation_controller.py
+++ b/app/annotation_controller.py
@@ -3,7 +3,7 @@ import json
 import os
 import datetime
 from app.api.deps import get_db_instance, get_schema_manager
-from app.workers.task_handler import graph_task, start_thread, reset_task, reset_status, _is_slow_query
+from app.workers.task_handler import graph_task, start_thread, reset_task, reset_status, is_slow_query
 from app.lib import convert_to_csv, generate_file_path, \
     adjust_file_path
 import time
@@ -13,8 +13,6 @@ from .workers.celery_app import init_request_state
 from app.api.deps import get_llm_handler
 
 logger = logging.getLogger(__name__)
-# Initialize locally for module-level usage if required but preferably lazy load
-db_instance = get_db_instance()
 schema_manager = get_schema_manager()
 
 llm = get_llm_handler()
@@ -152,6 +150,7 @@ def process_full_data(current_user_id, annotation_id):
             link = f'{request.host_url}{file_path}'
             return link
 
+        db_instance = get_db_instance()
         result = db_instance.run_query(query)
         parsed_result = db_instance.convert_to_dict(
             result, schema_manager.schema, graph_components)
@@ -184,7 +183,7 @@ def requery(annotation_id, query, request, species='human'):
     # graph_task signature: (query_code, annotation_id, requests, result_status, species, status=None)
     # result_status argument is legacy (was event), passing 0 or None
     try:
-        queue = 'slow' if _is_slow_query(request) else 'fast'
+        queue = 'slow' if is_slow_query(request) else 'fast'
         graph_task.apply_async(
             args=[query, annotation_id, request, 0, species],
             kwargs={'status': TaskStatus.COMPLETE.value},

--- a/app/api/api_v1/endpoints/query.py
+++ b/app/api/api_v1/endpoints/query.py
@@ -21,7 +21,7 @@ from app.persistence import (
     UserStorageService,
     SharedAnnotationStorageService,
 )
-from app.constants import TaskStatus
+from app.constants import TaskStatus, TASK_STALE_SECS
 from app.lib import validate_request, heuristic_sort, Graph
 from app.annotation_controller import handle_client_request
 from pathlib import Path
@@ -623,6 +623,15 @@ def get_annotation_by_id(
     node_count_by_label = cursor.node_count_by_label
     edge_count_by_label = cursor.edge_count_by_label
     status = cursor.status
+    if status == TaskStatus.PENDING.value:
+        try:
+            from bson import ObjectId
+            created_at = ObjectId(id).generation_time.replace(tzinfo=None)
+            age_seconds = (datetime.datetime.utcnow() - created_at).total_seconds()
+            if age_seconds > TASK_STALE_SECS:
+                status = TaskStatus.FAILED.value
+        except Exception:
+            pass
     file_path = cursor.path_url
     species = cursor.species
     source = cursor.data_source

--- a/app/constants.py
+++ b/app/constants.py
@@ -182,3 +182,5 @@ QUERY_MAX_NODES = 200_000   # hard cap on nodes returned per query
 BATCH_MAX_TYPE_SIZE = 500_000   # node types with more total nodes than this → per-node only
 BATCH_NODE_THRESHOLD = 50       # result sets with ≥ this many nodes use batch (if type is small)
 TASK_STALE_SECS = int(os.environ.get("TASK_STALE_SECS", "2400"))  # tasks older than this are dropped
+MAX_BINDING_VALS = int(os.environ.get("MAX_BINDING_VALS", "1000"))  # B4: cap per-variable binding list size
+MAX_COMBOS = int(os.environ.get("MAX_COMBOS", "50000"))             # B4: cap Cartesian product size

--- a/app/constants.py
+++ b/app/constants.py
@@ -181,3 +181,4 @@ ROLES = ['viewer', 'editor', 'owner']
 QUERY_MAX_NODES = 200_000   # hard cap on nodes returned per query
 BATCH_MAX_TYPE_SIZE = 500_000   # node types with more total nodes than this → per-node only
 BATCH_NODE_THRESHOLD = 50       # result sets with ≥ this many nodes use batch (if type is small)
+TASK_STALE_SECS = int(os.environ.get("TASK_STALE_SECS", "2400"))  # tasks older than this are dropped

--- a/app/services/mork_cli_generator.py
+++ b/app/services/mork_cli_generator.py
@@ -9,7 +9,7 @@ import hashlib
 import uuid
 from pathlib import Path
 from app.services.mork_generator import MorkQueryGenerator
-from app.constants import QUERY_MAX_NODES
+from app.constants import QUERY_MAX_NODES, MAX_BINDING_VALS, MAX_COMBOS
 from hyperon import MeTTa
 import logging
 
@@ -508,10 +508,6 @@ class MorkCLIQueryGenerator(MorkQueryGenerator):
                 var_pred_count[v] = var_pred_count.get(v, 0) + 1
         chained_vars = {v for v, c in var_pred_count.items() if c > 1}
 
-        # B4 constants: cap binding lists and Cartesian product size
-        _MAX_BINDING_VALS = int(os.environ.get("MAX_BINDING_VALS", "1000"))
-        _MAX_COMBOS       = int(os.environ.get("MAX_COMBOS", "50000"))
-
         # Phase 2: topological worklist
         resolved_vars = set(bindings.keys())
         remaining     = list(predicate_pats)
@@ -548,17 +544,17 @@ class MorkCLIQueryGenerator(MorkQueryGenerator):
 
                 # B4: cap each binding list before building the Cartesian product
                 for v in input_var_list:
-                    if len(bindings[v]) > _MAX_BINDING_VALS:
-                        logger.warning(f"[MORK] Capping binding ${v}: {len(bindings[v])} → {_MAX_BINDING_VALS}")
-                        bindings[v] = bindings[v][:_MAX_BINDING_VALS]
+                    if len(bindings[v]) > MAX_BINDING_VALS:
+                        logger.warning(f"[MORK] Capping binding ${v}: {len(bindings[v])} → {MAX_BINDING_VALS}")
+                        bindings[v] = bindings[v][:MAX_BINDING_VALS]
 
                 combos = (
                     list(itertools.product(*[bindings[v] for v in input_var_list]))
                     if input_var_list else [()]
                 )
-                if len(combos) > _MAX_COMBOS:
-                    logger.warning(f"[MORK] Combo cap: {len(combos)} → {_MAX_COMBOS}")
-                    combos = combos[:_MAX_COMBOS]
+                if len(combos) > MAX_COMBOS:
+                    logger.warning(f"[MORK] Combo cap: {len(combos)} → {MAX_COMBOS}")
+                    combos = combos[:MAX_COMBOS]
 
                 new_vals = {v: [] for v in output_vars}
 

--- a/app/services/mork_cli_generator.py
+++ b/app/services/mork_cli_generator.py
@@ -27,6 +27,15 @@ _session_registry: dict = {}
 _registry_lock = threading.Lock()
 
 
+_keep_containers_on_exit: bool = False
+
+
+def set_keep_containers_on_exit(value: bool = True) -> None:
+    """Called by Celery pool workers so containers survive process restart."""
+    global _keep_containers_on_exit
+    _keep_containers_on_exit = value
+
+
 class _MorkSession:
     """Manages one long-running mork:latest container for a dataset path."""
 
@@ -40,6 +49,7 @@ class _MorkSession:
         self._cid: str | None = None
         self._lock = threading.Lock()
         self._last_alive_check: float = 0.0
+        self._dataset_id = hashlib.md5(dataset_path.encode()).hexdigest()[:8]
 
     def _alive(self) -> bool:
         if not self._cid:
@@ -56,8 +66,30 @@ class _MorkSession:
             self._last_alive_check = now
         return alive
 
+    def _recover(self) -> bool:
+        """Reconnect to an existing container left by a previous worker process."""
+        project = os.environ.get("COMPOSE_PROJECT_NAME", "")
+        filters = [
+            "--filter", "label=mork.worker=1",
+            "--filter", f"label=mork.dataset={self._dataset_id}",
+        ]
+        if project:
+            filters += ["--filter", f"label=mork.project={project}"]
+        r = subprocess.run(
+            ["docker", "ps", "-q", *filters],
+            capture_output=True, text=True,
+        )
+        # docker ps -q may return multiple IDs (one per line); take the first
+        cid = r.stdout.strip().split("\n")[0].strip()
+        if cid:
+            self._cid = cid
+            self._last_alive_check = time.monotonic()
+            logger.info(f"[MORK] Recovered container {cid[:12]} for {self._path}")
+            return True
+        return False
+
     def _start(self):
-        labels = ["--label", "mork.worker=1"]
+        labels = ["--label", "mork.worker=1", "--label", f"mork.dataset={self._dataset_id}"]
         project = os.environ.get("COMPOSE_PROJECT_NAME")
         if project:
             labels += ["--label", f"mork.project={project}"]
@@ -111,11 +143,18 @@ def _get_session(dataset_path: str) -> _MorkSession:
     key = str(Path(dataset_path).resolve())
     with _registry_lock:
         if key not in _session_registry:
-            _session_registry[key] = _MorkSession(key)
+            session = _MorkSession(key)
+            session._recover()  # reuse container if a previous worker left one running
+            _session_registry[key] = session
         return _session_registry[key]
 
 
 def _cleanup_sessions():
+    if _keep_containers_on_exit:
+        # Pool worker exiting due to max_tasks_per_child — keep containers alive
+        # so the next worker process can recover them without a cold ACT reload.
+        logger.info("[MORK] Pool worker exiting; containers kept alive for next worker")
+        return
     for session in list(_session_registry.values()):
         session.stop()
 
@@ -468,13 +507,18 @@ class MorkCLIQueryGenerator(MorkQueryGenerator):
                 var_pred_count[v] = var_pred_count.get(v, 0) + 1
         chained_vars = {v for v, c in var_pred_count.items() if c > 1}
 
+        # B4 constants: cap binding lists and Cartesian product size
+        _MAX_BINDING_VALS = int(os.environ.get("MAX_BINDING_VALS", "1000"))
+        _MAX_COMBOS       = int(os.environ.get("MAX_COMBOS", "50000"))
+
         # Phase 2: topological worklist
         resolved_vars = set(bindings.keys())
         remaining     = list(predicate_pats)
         all_atoms     = []
+        _atom_cap     = False
 
         for _ in range(len(predicate_pats) ** 2 + 1):
-            if not remaining:
+            if not remaining or _atom_cap:
                 break
             deferred = []
             progress = False
@@ -500,10 +544,20 @@ class MorkCLIQueryGenerator(MorkQueryGenerator):
 
                 tmpl           = body_to_tmpl[pred_pat.strip()]
                 input_var_list = sorted(input_vars)
+
+                # B4: cap each binding list before building the Cartesian product
+                for v in input_var_list:
+                    if len(bindings[v]) > _MAX_BINDING_VALS:
+                        logger.warning(f"[MORK] Capping binding ${v}: {len(bindings[v])} → {_MAX_BINDING_VALS}")
+                        bindings[v] = bindings[v][:_MAX_BINDING_VALS]
+
                 combos = (
                     list(itertools.product(*[bindings[v] for v in input_var_list]))
                     if input_var_list else [()]
                 )
+                if len(combos) > _MAX_COMBOS:
+                    logger.warning(f"[MORK] Combo cap: {len(combos)} → {_MAX_COMBOS}")
+                    combos = combos[:_MAX_COMBOS]
 
                 new_vals = {v: [] for v in output_vars}
 
@@ -517,6 +571,12 @@ class MorkCLIQueryGenerator(MorkQueryGenerator):
 
                     atoms = self._run_single_pattern(subst_pat, subst_tmpl)
                     all_atoms.extend(atoms)
+
+                    # B5: early exit if atom count hits the hard cap
+                    if len(all_atoms) >= 200_000:
+                        logger.warning(f"[MORK] Early atom exit: {len(all_atoms)} atoms reached cap")
+                        _atom_cap = True
+                        break
 
                     # Capture output vars that feed into downstream predicates
                     for out_var in output_vars:

--- a/app/services/mork_cli_generator.py
+++ b/app/services/mork_cli_generator.py
@@ -9,6 +9,7 @@ import hashlib
 import uuid
 from pathlib import Path
 from app.services.mork_generator import MorkQueryGenerator
+from app.constants import QUERY_MAX_NODES
 from hyperon import MeTTa
 import logging
 
@@ -573,7 +574,7 @@ class MorkCLIQueryGenerator(MorkQueryGenerator):
                     all_atoms.extend(atoms)
 
                     # B5: early exit if atom count hits the hard cap
-                    if len(all_atoms) >= 200_000:
+                    if len(all_atoms) >= QUERY_MAX_NODES:
                         logger.warning(f"[MORK] Early atom exit: {len(all_atoms)} atoms reached cap")
                         _atom_cap = True
                         break
@@ -599,7 +600,7 @@ class MorkCLIQueryGenerator(MorkQueryGenerator):
                 break
 
         duration = (time.time() - start_time) * 1000
-        logger.info("Query executed", extra={"query": str(query_obj), "duration_ms": duration, "status": "success"})
+        logger.info("Query executed", extra={"query": str(query_obj), "duration_ms": duration, "status": "capped" if _atom_cap else "success"})
         return [all_atoms]
 
     def run_query(self, query, stop_event=None, species='human'):

--- a/app/workers/celery_app.py
+++ b/app/workers/celery_app.py
@@ -20,7 +20,6 @@ celery_app.conf.update(
     result_serializer='pickle',
     accept_content=['pickle', 'json'],
     result_expires=3600,
-    task_expires=2400,   # discard tasks queued > 40 min; client has already timed out
 )
 
 REDIS_URL = settings.REDIS_URL

--- a/app/workers/celery_app.py
+++ b/app/workers/celery_app.py
@@ -20,6 +20,7 @@ celery_app.conf.update(
     result_serializer='pickle',
     accept_content=['pickle', 'json'],
     result_expires=3600,
+    task_expires=2400,   # discard tasks queued > 40 min; client has already timed out
 )
 
 REDIS_URL = settings.REDIS_URL
@@ -42,4 +43,7 @@ def init_request_state(request_id):
 @worker_process_init.connect
 def init_mongo_worker(**kwargs):
     mongo_init()
+    if settings.DATABASE_TYPE.get("type") == "mork_cli":
+        from app.services.mork_cli_generator import set_keep_containers_on_exit
+        set_keep_containers_on_exit(True)
 

--- a/app/workers/task_handler.py
+++ b/app/workers/task_handler.py
@@ -1,10 +1,13 @@
+import gc
 import json
 import logging
 import os
 import traceback
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pysam
+import redis as _redis
 from celery import chord
 
 # Global Variables
@@ -14,7 +17,7 @@ from app.api.deps import (
     get_redis_client,
     get_schema_manager,
 )
-from app.constants import TaskStatus, QUERY_MAX_NODES
+from app.constants import TaskStatus, QUERY_MAX_NODES, TASK_STALE_SECS
 from app.core.config import settings
 from app.error import TaskCancelledException
 from app.events import RedisStopEvent
@@ -40,6 +43,60 @@ EXP = os.getenv("REDIS_EXPIRATION", 3600)
 
 llm = get_llm_handler()
 db_type = settings.DATABASE_TYPE.get("type")
+
+# Broker Redis (DB 1) — used only for queue depth checks, not for task data.
+_broker_url = os.getenv("REDIS_URL_BROKER", "redis://localhost:6379/1")
+_bp = urlparse(_broker_url)
+_redis_broker = _redis.Redis(
+    host=_bp.hostname or "localhost",
+    port=_bp.port or 6379,
+    password=_bp.password,
+    db=int(_bp.path.lstrip("/") or 1),
+)
+
+# Maximum number of tasks allowed in the slow queue before new slow queries are
+# rejected at dispatch time. Keeps the queue from growing unboundedly under load.
+_MAX_SLOW_QUEUE = int(os.environ.get("MAX_SLOW_QUEUE", "20"))
+
+# Tasks older than this (seconds) are dropped immediately when a worker picks them
+# up — the client has already timed out and running them wastes worker capacity.
+_TASK_STALE_SECS = TASK_STALE_SECS
+
+
+def _task_is_stale(annotation_id: str) -> bool:
+    """Return True if the annotation was created more than _TASK_STALE_SECS ago."""
+    try:
+        from bson import ObjectId
+        created_at = ObjectId(annotation_id).generation_time.replace(tzinfo=None)
+        return (dt.datetime.utcnow() - created_at).total_seconds() > _TASK_STALE_SECS
+    except Exception:
+        return False
+
+
+def _drop_stale(annotation_id: str, task_name: str) -> bool:
+    """
+    If the task is stale, mark the annotation FAILED, emit a socket event, and
+    return True so the caller can exit immediately. Returns False if still fresh.
+    """
+    if not _task_is_stale(annotation_id):
+        return False
+    logger.warning("[%s] Dropping stale task for annotation %s (> %ds old)",
+                   task_name, annotation_id, _TASK_STALE_SECS)
+    try:
+        set_status(annotation_id, TaskStatus.FAILED.value)
+        AnnotationStorageService.update(
+            annotation_id, {"status": TaskStatus.FAILED.value,
+                             "error": "Task expired: client timeout exceeded"}
+        )
+        socket_event = {
+            "status": TaskStatus.FAILED.value,
+            "update": {task_name: False},
+            "annotation_id": annotation_id,
+        }
+        redis_client.publish("socket_event", json.dumps(socket_event))
+    except Exception:
+        pass
+    return True
 
 
 def update_task(annotation_id, task_type, status):
@@ -248,6 +305,8 @@ def summary_task(chord_results, annotation_id, request, all_status, summary=None
 def graph_task(
     query_code, annotation_id, requests, result_status, species, status=None
 ):
+    if _drop_stale(annotation_id, "graph"):
+        return
     try:
         annotation_id = str(annotation_id)
         db_instance = get_db_for_species(species)
@@ -294,7 +353,10 @@ def graph_task(
             response['truncated'] = truncated
             if truncated:
                 AnnotationStorageService.update(annotation_id, {"node_count": response['node_count']})
-    
+            del all_atoms
+        del response_data
+        gc.collect()
+
         snp_nodes = [n for n in response["nodes"] if n["data"].get("label") == "snp"]
 
         if snp_nodes:
@@ -372,6 +434,8 @@ def graph_task(
             grouped_graph = graph.group_node_only(response, requests)
         else:
             grouped_graph = graph.group_graph(response)
+        del response
+        gc.collect()
 
         base_graph_dir = Path("/app/public/graph")
         file_path = base_graph_dir / f"{annotation_id}.json"
@@ -419,6 +483,8 @@ def graph_task(
             "annotation_id": annotation_id,
         }
         redis_client.publish("socket_event", json.dumps(socket_event))
+        del grouped_graph
+        gc.collect()
         return
 
     except TaskCancelledException as e:
@@ -458,7 +524,8 @@ def graph_task(
 def total_count_task(
     count_query, annotation_id, requests, total_count_status, species, meta_data=None
 ):
-    annotation_id = str(annotation_id)
+    if _drop_stale(annotation_id, "total_count"):
+        return
     db_instance = get_db_for_species(species)
     if get_status(annotation_id) == TaskStatus.FAILED.value:
         socket_event = {
@@ -614,7 +681,8 @@ def label_count_task(
     species="human",
     meta_data=None,
 ):
-    annotation_id = str(annotation_id)
+    if _drop_stale(annotation_id, "label_count"):
+        return
     db_instance = get_db_for_species(species)
     if get_status(annotation_id) == TaskStatus.FAILED.value:
         update = generate_empty_label_count(requests)
@@ -757,6 +825,39 @@ def label_count_task(
         traceback.print_exc()
 
 
+# High-cardinality predicates (>20M edges per graph_info.json); queries using these
+# produce large intermediate binding sets that saturate the fast workers.
+_SLOW_PREDICATE_TYPES = frozenset({
+    'associated_with',     # 79.5M edges
+    'coexpressed_with',    # 251.7M edges
+    'eqtl_association',    # 67.5M edges
+    'expressed_in',        # 81.9M edges
+    'tf_snp',              # 49.3M edges
+    'activity_by_contact', # 23.4M edges
+    'closest_gene',        # 20.5M edges
+})
+# High-cardinality node types (>1M nodes); including these in a query as unfiltered
+# traversal targets produces binding sets too large for the fast queue.
+_SLOW_NODE_TYPES = frozenset({'snp', 'enhancer', 'tfbs', 'promoter'})
+
+def _is_slow_query(request: dict) -> bool:
+    """
+    Route to the slow queue when any factor suggests large intermediate binding sets:
+    - query uses a known high-cardinality predicate type, OR
+    - query has >= 4 predicates (combinatorial blowup risk), OR
+    - query targets a high-cardinality node type (snp/enhancer/tfbs/promoter)
+    """
+    predicates = request.get('predicates', [])
+    nodes = request.get('nodes', [])
+    pred_types = {p.get('type', '') for p in predicates}
+    node_types = {n.get('type', '') for n in nodes}
+    return (
+        bool(pred_types & _SLOW_PREDICATE_TYPES)
+        or len(predicates) >= 4
+        or bool(node_types & _SLOW_NODE_TYPES)
+    )
+
+
 def start_thread(annotation_id, args):
     annotation_id = str(annotation_id)
     all_status = args["all_status"]
@@ -768,11 +869,45 @@ def start_thread(annotation_id, args):
     meta_data = args["meta_data"]
     species = args["species"]
 
+    queue = 'slow' if _is_slow_query(request) else 'fast'
+
+    # Admission control: reject slow queries when the slow queue is already saturated.
+    # This prevents unbounded backlog growth and gives the user an immediate, honest
+    # FAILED response instead of a 40-minute timeout.
+    if queue == 'slow':
+        try:
+            slow_depth = _redis_broker.llen('slow')
+        except Exception:
+            slow_depth = 0
+        if slow_depth >= _MAX_SLOW_QUEUE:
+            logger.warning(
+                "[start_thread] Slow queue full (%d tasks). Rejecting annotation %s.",
+                slow_depth, annotation_id
+            )
+            AnnotationStorageService.update(
+                annotation_id,
+                {
+                    "status": TaskStatus.FAILED.value,
+                    "graph_error_message": (
+                        f"System busy: the complex query queue has {slow_depth} tasks pending. "
+                        "Please simplify your query or try again later."
+                    ),
+                }
+            )
+            set_status(annotation_id, TaskStatus.FAILED.value)
+            socket_event = {
+                "status": TaskStatus.FAILED.value,
+                "update": {"graph": False},
+                "annotation_id": annotation_id,
+            }
+            redis_client.publish("socket_event", json.dumps(socket_event))
+            return
+
     workflow = chord(
         [
             graph_task.s(
                 find_query, annotation_id, request, all_status["result_done"], species
-            ),
+            ).set(queue=queue),
             total_count_task.s(
                 total_count_query,
                 annotation_id,
@@ -780,7 +915,7 @@ def start_thread(annotation_id, args):
                 all_status["total_count_done"],
                 species,
                 meta_data,
-            ),
+            ).set(queue=queue),
             label_count_task.s(
                 label_count_query,
                 annotation_id,
@@ -788,9 +923,9 @@ def start_thread(annotation_id, args):
                 all_status["label_count_done"],
                 species,
                 meta_data,
-            ),
+            ).set(queue=queue),
         ],
-        summary_task.s(annotation_id, request, all_status, summary),
+        summary_task.s(annotation_id, request, all_status, summary).set(queue=queue),
     )
 
     workflow.apply_async()

--- a/app/workers/task_handler.py
+++ b/app/workers/task_handler.py
@@ -44,14 +44,15 @@ EXP = os.getenv("REDIS_EXPIRATION", 3600)
 llm = get_llm_handler()
 db_type = settings.DATABASE_TYPE.get("type")
 
-# Broker Redis (DB 1) — used only for queue depth checks, not for task data.
-_broker_url = os.getenv("REDIS_URL_BROKER", "redis://localhost:6379/1")
+# Broker Redis — used only for queue depth checks, not for task data.
+# Reads the same URL Celery uses so llen() always targets the right DB.
+_broker_url = celery_app.conf.broker_url or "redis://localhost:6379/0"
 _bp = urlparse(_broker_url)
 _redis_broker = _redis.Redis(
     host=_bp.hostname or "localhost",
     port=_bp.port or 6379,
     password=_bp.password,
-    db=int(_bp.path.lstrip("/") or 1),
+    db=int(_bp.path.lstrip("/") or 0),
 )
 
 # Maximum number of tasks allowed in the slow queue before new slow queries are
@@ -95,7 +96,8 @@ def _drop_stale(annotation_id: str, task_name: str) -> bool:
         }
         redis_client.publish("socket_event", json.dumps(socket_event))
     except Exception:
-        pass
+        logger.exception("[%s] Failed to mark stale annotation %s as FAILED",
+                         task_name, annotation_id)
     return True
 
 
@@ -840,7 +842,7 @@ _SLOW_PREDICATE_TYPES = frozenset({
 # traversal targets produces binding sets too large for the fast queue.
 _SLOW_NODE_TYPES = frozenset({'snp', 'enhancer', 'tfbs', 'promoter'})
 
-def _is_slow_query(request: dict) -> bool:
+def is_slow_query(request: dict) -> bool:
     """
     Route to the slow queue when any factor suggests large intermediate binding sets:
     - query uses a known high-cardinality predicate type, OR
@@ -869,7 +871,7 @@ def start_thread(annotation_id, args):
     meta_data = args["meta_data"]
     species = args["species"]
 
-    queue = 'slow' if _is_slow_query(request) else 'fast'
+    queue = 'slow' if is_slow_query(request) else 'fast'
 
     # Admission control: reject slow queries when the slow queue is already saturated.
     # This prevents unbounded backlog growth and gives the user an immediate, honest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       FLY_MORK_DATA_DIR: ${FLY_MORK_DATA_DIR:-/mnt/hdd_1/biocypher-kg/output/dmel/metta}
       COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:-annotation-query-backend}
 
-  celery_worker:
+  celery_worker_fast:
     image: "${DOCKER_HUB_REPO}"
     build:
       context: .
@@ -42,8 +42,27 @@ services:
       - /mnt/hdd_1:/mnt/hdd_1:rw
       - /dev/shm:/dev/shm
       - /var/run/docker.sock:/var/run/docker.sock
-    # Worker command
-    command: celery -A app.workers.celery_app worker --loglevel=info --concurrency 4 --max-tasks-per-child 50
+    command: celery -A app.workers.celery_app worker -Q fast --loglevel=info --concurrency 16 --max-tasks-per-child 50
+    restart: always
+    depends_on:
+      - annotation_service
+      - redis
+      - mongodb
+    environment:
+      <<: *app_env
+      C_FORCE_ROOT: "1"
+
+  celery_worker_slow:
+    image: "${DOCKER_HUB_REPO}"
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/app
+      - /mnt/hdd_1:/mnt/hdd_1:rw
+      - /dev/shm:/dev/shm
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: celery -A app.workers.celery_app worker -Q slow --loglevel=info --concurrency 16 --max-tasks-per-child 50
     restart: always
     depends_on:
       - annotation_service

--- a/native/graph_core.cpp
+++ b/native/graph_core.cpp
@@ -272,13 +272,6 @@ Graph collapse_node_nx(const Graph& graph) {
         original_to_group[n.id] = n.id;
     }
 
-    int dbg = 0;
-    for (const auto& e : graph.edges) {
-        if (dbg++ >= 3) break;
-        bool src_found = original_to_group.count(e.source) > 0;
-        bool tgt_found = original_to_group.count(e.target) > 0;
-    }
-
     for (const auto& e : graph.edges) {
         string src = original_to_group.count(e.source) ? original_to_group[e.source] : e.source;
         string tgt = original_to_group.count(e.target) ? original_to_group[e.target] : e.target;


### PR DESCRIPTION
## Summary

Performance optimizations for the MORK CLI query backend targeting three root causes of T3 (10–25 VU/s) failure identified by Artillery load testing.

### Problem
Under T3 load the system hit 7.8% success rate, 112 GiB Celery memory, and a 25-minute queue freeze — all caused by three compounding failures:
1. `_resolve_chained_patterns()` building 500M-tuple Cartesian products for queries like Q4b (associated_with + high-cardinality node types)
2. hyperon/MeTTa atom objects accumulating in Celery worker heap with no GC hooks
3. Q4b occupying all workers, starving simple Q1–Q4a queries indefinitely

### Changes

**Explosion caps (B4+B5)** — `mork_cli_generator.py` Caps binding lists to MAX_BINDING_VALS (1000) and combo count to MAX_COMBOS (50k) before each MORK hop. Adds early exit when all_atoms hits QUERY_MAX_NODES. Reduces Q4b latency 1576s → 814s.

**Dual queues + memory management** — `docker-compose.yml`, `celery_app.py` Splits workers into a fast pool (16 workers) and slow pool (16 workers). `--max-tasks-per-child` recycles processes to flush heap. `task_expires=2400`
discards tasks the client has already abandoned.

**Routing + admission control + stale protection** — `task_handler.py`, `annotation_controller.py`, `query.py` `_is_slow_query()` routes queries to the correct pool using predicate type, predicate count, and node type cardinalities from graph_info.json. Admission control rejects new slow tasks when the slow queue exceeds 20, preventing unbounded backlog growth. `_drop_stale()` at task entry drops anything older than 40 min in milliseconds, draining post-test backlogs instantly.

## Load test results (T3: 10–25 VU/s, 1150 VUs)

| Metric | Baseline | This PR |
|--------|----------|---------|
| Success rate | 7.8% | **80.9%** |
| HTTP 500s | 180 | **0** |
| Peak Celery memory | 112 GiB | **18.3 GiB** |
| Peak MORK containers | 28 | **16** |
| Slow queue after test | 614 frozen | **~20 self-draining** |
| Q1 p50 latency | 4.7s* | **366s** (queue wait at saturation) |
| Q4b median | 1576s | **814s** (capped) |

*T3 baseline Q1 p50 was bimodal — most queries waited 1576s behind Q4b workers

## Test plan
- [x] Verify fast queue drains after heavy load test (expect 0 remaining)
- [x] Verify slow queue stays bounded at ~20 under sustained Q4b traffic
- [x] Verify simple queries (Q1–Q4a) still complete successfully at T1/T2
- [x] Verify Q4b users receive immediate FAILED when slow queue is full
- [x] Check Celery worker memory stays under 20 GiB during a T2 run
