### PR TITLE
Fix Cypher query generation and pipeline reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,17 @@ flask run
 2. **Configure Environment Variables**:
    Create a `.env` file in the root folder with the following content:
    ```plaintext
-   NEO4J_URL=your_neo4j_url
-   NEO4J_USERNAME =your_neo4j_user
-   NEO4J_PASSWORD=your_neo4j_password
+   HUMAN_NEO4J_URI=bolt://your-neo4j-host:7687
+   HUMAN_NEO4J_USERNAME=neo4j
+   HUMAN_NEO4J_PASSWORD=your_password
+
+   # Optional — leave commented out if fly (DMEL) data is not yet available.
+   # FLY_NEO4J_URI=bolt://your-fly-neo4j-host:7688
+   # FLY_NEO4J_USERNAME=neo4j
+   # FLY_NEO4J_PASSWORD=your_password
    ```
+   The fly Neo4j driver is created only when `FLY_NEO4J_URI` is set. Omitting it
+   logs a warning but does not prevent human-species queries from working.
 3. **Run**:
    Ensure you are in the root directory of the project and then run:
 
@@ -178,6 +185,9 @@ There should be this environment variable in your .env file
    CADDY_PORT=<the port on which Caddy will listen for incoming requests>
 
    CADDY_PORT_FORWARD=<the internal port inside the Docker container where Caddy forwards requests to>
+
+   # Feature flags (optional — shown with their defaults)
+   DEDUP_ENABLED=true   # set to false to disable request deduplication
    ```
 
 ## Script Usage
@@ -247,3 +257,21 @@ sudo ./run.sh re-run
    ```bash
    sudo ./run.sh clean
    ```
+
+## Feature Flags
+
+Feature flags are environment variables that can be passed at `docker compose up` time or set in `.env`.
+
+### `DEDUP_ENABLED` (default: `true`)
+
+Controls whether repeated identical queries are served from the cache instead of re-running the full pipeline.
+
+When `true` (default), the service fingerprints each incoming query. If a completed annotation with the same fingerprint already exists in MongoDB it is returned immediately, skipping Neo4j / MORK entirely.
+
+Set to `false` to force a fresh query execution every time — useful during development or when debugging pipeline output:
+
+```bash
+DEDUP_ENABLED=false docker compose up -d --no-deps annotation_service celery_worker_fast celery_worker_slow
+```
+
+Disabling dedup does **not** affect fingerprint storage — every new annotation is still fingerprinted and saved.

--- a/app/api/api_v1/endpoints/query.py
+++ b/app/api/api_v1/endpoints/query.py
@@ -195,7 +195,7 @@ def process_query(
         lock_key = f"dedup_lock:{fingerprint}"
         with redis_client.lock(lock_key, timeout=10, blocking_timeout=5):
             existing_doc = AnnotationStorageService.get_by_fingerprint(fingerprint)
-            if existing_doc and existing_doc.status == TaskStatus.COMPLETE.value and not annotation_id:
+            if settings.DEDUP_ENABLED and existing_doc and existing_doc.status == TaskStatus.COMPLETE.value and not annotation_id:
                 # HYPOTHESIS source — never has a question, safe to return
                 # graph nodes directly from cache.
                 if source == "hypothesis":

--- a/app/api/api_v1/endpoints/query.py
+++ b/app/api/api_v1/endpoints/query.py
@@ -640,6 +640,7 @@ def get_annotation_by_id(
     files = cursor.files
     retrieval_duration = cursor.retrieval_duration
     processing_duration = cursor.processing_duration
+    summary_duration = cursor.summary_duration
     total_duration = cursor.total_duration
     graph_error_message = cursor.graph_error_message
     count_error_message = cursor.count_error_message
@@ -663,6 +664,7 @@ def get_annotation_by_id(
         response_data["edge_count_by_label"] = edge_count_by_label
     if retrieval_duration: response_data["retrieval_duration"] = retrieval_duration
     if processing_duration: response_data["processing_duration"] = processing_duration
+    if summary_duration: response_data["summary_duration"] = summary_duration
     if total_duration: response_data["total_duration"] = total_duration
     if graph_error_message: response_data["graph_error_message"] = graph_error_message
     if count_error_message: response_data["count_error_message"] = count_error_message

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -43,6 +43,9 @@ class Settings(BaseSettings):
     # Mongo
     MONGO_URI: Optional[str] = None
 
+    # Feature flags
+    DEDUP_ENABLED: bool = True
+
     class Config:
         case_sensitive = True
         env_file = ".env"

--- a/app/models/annotation.py
+++ b/app/models/annotation.py
@@ -28,6 +28,7 @@ class Annotation(Schema):
     path_url = None
     retrieval_duration = None
     processing_duration = None
+    summary_duration = None
     total_duration = None
     query_fingerprint = None
     participant_user_ids = None
@@ -73,6 +74,7 @@ class Annotation(Schema):
             "path_url": Types.String,
             "retrieval_duration": Types.String,
             "processing_duration": Types.String,
+            "summary_duration": Types.String,
             "total_duration": Types.String,
             "graph_error_message": {"type": Types.String},
             "count_error_message": {"type": Types.String},

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -56,16 +56,22 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             retry_policy=_DEFAULT_POLICY,
             timeout_config=_TIMEOUT_CONFIG,
         )
-        self.fly_driver = ResilientDriver(
-            uri=os.getenv('FLY_NEO4J_URI'),
-            auth=(os.getenv('FLY_NEO4J_USERNAME'), os.getenv('FLY_NEO4J_PASSWORD')),
-            retry_policy=_DEFAULT_POLICY,
-            timeout_config=_TIMEOUT_CONFIG,
-        )
+        fly_uri = os.getenv('FLY_NEO4J_URI')
+        if fly_uri:
+            self.fly_driver = ResilientDriver(
+                uri=fly_uri,
+                auth=(os.getenv('FLY_NEO4J_USERNAME'), os.getenv('FLY_NEO4J_PASSWORD')),
+                retry_policy=_DEFAULT_POLICY,
+                timeout_config=_TIMEOUT_CONFIG,
+            )
+        else:
+            logger.warning("FLY_NEO4J_URI not set — fly species queries will not be available.")
+            self.fly_driver = None
 
     def close(self):
         self.human_driver.close()
-        self.fly_driver.close()
+        if self.fly_driver is not None:
+            self.fly_driver.close()
 
     def load_dataset(self, path: str) -> None:
         if not os.path.exists(path):
@@ -102,8 +108,12 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             f"Finished loading {len(nodes_paths)} nodes and {len(edges_paths)} edges datasets.")
 
     def run_query(self, query_code, stop_event=None, species="human", query_type: QueryType = QueryType.DEFAULT):
-        driver = self.human_driver if species == "human" else self.fly_driver
-        # use lazy loading for improved performance
+        if species != "human":
+            if self.fly_driver is None:
+                raise RuntimeError("Fly Neo4j driver is not configured. Set FLY_NEO4J_URI.")
+            driver = self.fly_driver
+        else:
+            driver = self.human_driver
         return driver.run_with_retry(query_code, stop_event=stop_event, query_type=query_type)
 
     def _find_anchor_node(self, predicates):
@@ -282,7 +292,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                 inner_lines.append(f"  {virtual_creation}")
 
             # WITH inside CALL — carry prior aliases then add new collect
-            carry_str = ', '.join(carried) + (', ' if carried else '') + collect_expr
+            carry_str = anchor_var + ', ' + ', '.join(carried) + (', ' if carried else '') + collect_expr
             inner_lines.append(f"  WITH {carry_str}")
 
             carried.append(pred_id)
@@ -290,7 +300,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         # Final RETURN inside CALL
         inner_lines.append(f"  RETURN {', '.join(aliases)}")
 
-        call_block = "CALL ({}) {{\n{}\n}}".format(anchor_var, '\n'.join(inner_lines))
+        call_block = "CALL {{\n  WITH {}\n{}\n}}".format(anchor_var, '\n'.join(inner_lines))
 
         outer_return = f"RETURN {anchor_var}, {', '.join(aliases)}"
         limit_clause = f"LIMIT {limit}" if limit else ""

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -155,7 +155,8 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         Build a CALL-subquery-scoped Cypher query:
 
           MATCH (anchor_var:Type) WHERE <anchor conditions>
-          CALL (anchor_var) {
+          CALL {
+            WITH anchor_var
             MATCH <pred0 pattern> WHERE <pred0 conditions>
             WITH collect({<non-anchor node>: <var>, <pred_id>: <var>}) AS p0
             MATCH <pred1 pattern> WHERE <pred1 conditions>

--- a/app/workers/task_handler.py
+++ b/app/workers/task_handler.py
@@ -429,6 +429,23 @@ def graph_task(
 
             pysam.tabix_index(str(vcf_path), preset="vcf", force=True)
 
+        nodes_list = response.get("nodes", [])
+        edges_list = response.get("edges", [])
+        graph_node_count = len(nodes_list)
+        graph_edge_count = len(edges_list)
+
+        _node_type_counts = {}
+        for n in nodes_list:
+            t = n.get("data", {}).get("type", "unknown")
+            _node_type_counts[t] = _node_type_counts.get(t, 0) + 1
+        graph_node_count_by_label = [{"label": k, "count": v} for k, v in _node_type_counts.items()]
+
+        _edge_label_counts = {}
+        for e in edges_list:
+            lbl = e.get("data", {}).get("label", "unknown")
+            _edge_label_counts[lbl] = _edge_label_counts.get(lbl, 0) + 1
+        graph_edge_count_by_label = [{"label": k, "count": v} for k, v in _edge_label_counts.items()]
+
         graph = Graph()
 
         if len(response["edges"]) == 0 and len(response["nodes"]) > 0:
@@ -476,7 +493,15 @@ def graph_task(
         update_task(annotation_id, "graph", 1)
 
         # Save Result with Status
-        save_result_redis(annotation_id, {"status": status, "graph": grouped_graph, "task_start": task_start})
+        save_result_redis(annotation_id, {
+            "status": status,
+            "graph": grouped_graph,
+            "task_start": task_start,
+            "node_count": graph_node_count,
+            "edge_count": graph_edge_count,
+            "node_count_by_label": graph_node_count_by_label,
+            "edge_count_by_label": graph_edge_count_by_label,
+        })
 
         socket_event = {
             "status": status,
@@ -560,6 +585,29 @@ def total_count_task(
         return
 
     try:
+        if db_type == "cypher":
+            for _ in range(120):  # poll up to 60s; graph_task typically finishes in <10s
+                if get_status(annotation_id) in (TaskStatus.FAILED.value, TaskStatus.CANCELLED.value):
+                    return
+                cache = get_annotation_redis(annotation_id)
+                if cache and "node_count" in cache:
+                    node_count = cache["node_count"]
+                    edge_count = cache["edge_count"]
+                    update_task(annotation_id, "total_count", 1)
+                    AnnotationStorageService.update(
+                        annotation_id,
+                        {"node_count": node_count, "edge_count": edge_count, "status": TaskStatus.PENDING.value},
+                    )
+                    socket_event = {
+                        "status": TaskStatus.PENDING.value,
+                        "update": {"node_count": node_count, "edge_count": edge_count},
+                        "annotation_id": annotation_id,
+                    }
+                    redis_client.publish("socket_event", json.dumps(socket_event))
+                    return
+                time.sleep(0.5)
+            # fallback: graph_task didn't write counts in time — run Neo4j count query below
+
         total_count = db_instance.run_query(count_query, None, species)
 
         if db_type in ["mork", "mork_cli"]:
@@ -758,6 +806,29 @@ def label_count_task(
             }
             redis_client.publish("socket_event", json.dumps(socket_event))
             return
+
+        if db_type == "cypher":
+            for _ in range(120):  # poll up to 60s
+                if get_status(annotation_id) in (TaskStatus.FAILED.value, TaskStatus.CANCELLED.value):
+                    return
+                cache = get_annotation_redis(annotation_id)
+                if cache and "node_count_by_label" in cache:
+                    node_count_by_label = cache["node_count_by_label"]
+                    edge_count_by_label = cache["edge_count_by_label"]
+                    AnnotationStorageService.update(
+                        annotation_id,
+                        {"node_count_by_label": node_count_by_label, "edge_count_by_label": edge_count_by_label},
+                    )
+                    update_task(annotation_id, "label_count", 1)
+                    socket_event = {
+                        "status": TaskStatus.PENDING.value,
+                        "update": {"node_count_by_label": node_count_by_label, "edge_count_by_label": edge_count_by_label},
+                        "annotation_id": annotation_id,
+                    }
+                    redis_client.publish("socket_event", json.dumps(socket_event))
+                    return
+                time.sleep(0.5)
+            # fallback: graph_task didn't write counts in time — run Neo4j count query below
 
         label_count = db_instance.run_query(count_query, None, species)
         count_result = [{}, label_count[0]]

--- a/app/workers/task_handler.py
+++ b/app/workers/task_handler.py
@@ -235,11 +235,13 @@ def summary_task(chord_results, annotation_id, request, all_status, summary=None
         response["node_count_by_label"] = meta_data.node_count_by_label
         response["edge_count_by_label"] = meta_data.edge_count_by_label
 
+        t_summary = time.time()
         if len(response["nodes"]) == 0:
             summary = "No summary for this graph because the graph is empty"
         else:
             summary = llm.generate_summary(response, request)
             summary = summary if summary else "Graph too big, could not summarize"
+        summary_ms = round((time.time() - t_summary) * 1000)
 
         task_start = cache.get("task_start")
         total_ms = round((time.time() - task_start) * 1000) if task_start else None
@@ -248,6 +250,7 @@ def summary_task(chord_results, annotation_id, request, all_status, summary=None
             "summary": summary,
             "status": TaskStatus.COMPLETE.value,
             "total_duration": _format_duration(total_ms),
+            "summary_duration": _format_duration(summary_ms),
         })
         
         update_task(annotation_id, "summary", 1)

--- a/app/workers/task_handler.py
+++ b/app/workers/task_handler.py
@@ -201,8 +201,6 @@ def summary_task(chord_results, annotation_id, request, all_status, summary=None
         meta_data = AnnotationStorageService.get_by_id(annotation_id)
 
         if summary is not None:
-            created_at = getattr(meta_data, 'created_at', None)
-            total_ms = round((dt.datetime.now() - created_at).total_seconds() * 1000) if created_at else None
             update_task(annotation_id, "summary", 1)
             set_status(annotation_id, TaskStatus.COMPLETE.value)
             AnnotationStorageService.update(
@@ -243,8 +241,8 @@ def summary_task(chord_results, annotation_id, request, all_status, summary=None
             summary = llm.generate_summary(response, request)
             summary = summary if summary else "Graph too big, could not summarize"
 
-        created_at = getattr(meta_data, 'created_at', None)
-        total_ms = round((dt.datetime.now() - created_at).total_seconds() * 1000) if created_at else None
+        task_start = cache.get("task_start")
+        total_ms = round((time.time() - task_start) * 1000) if task_start else None
 
         AnnotationStorageService.update(annotation_id, {
             "summary": summary,
@@ -311,6 +309,7 @@ def graph_task(
         return
     try:
         annotation_id = str(annotation_id)
+        task_start = time.time()
         db_instance = get_db_for_species(species)
         check_for_cancellation(annotation_id)
 
@@ -477,7 +476,7 @@ def graph_task(
         update_task(annotation_id, "graph", 1)
 
         # Save Result with Status
-        save_result_redis(annotation_id, {"status": status, "graph": grouped_graph})
+        save_result_redis(annotation_id, {"status": status, "graph": grouped_graph, "task_start": task_start})
 
         socket_event = {
             "status": status,

--- a/app/workers/task_handler.py
+++ b/app/workers/task_handler.py
@@ -609,7 +609,10 @@ def total_count_task(
                     redis_client.publish("socket_event", json.dumps(socket_event))
                     return
                 time.sleep(0.5)
-            # fallback: graph_task didn't write counts in time — run Neo4j count query below
+            # graph_task didn't write counts within 60s — skip rather than falling back to a
+            # Neo4j count query that can hang and block the chord callback for cypher queries.
+            update_task(annotation_id, "total_count", 1)
+            return
 
         total_count = db_instance.run_query(count_query, None, species)
 
@@ -831,7 +834,10 @@ def label_count_task(
                     redis_client.publish("socket_event", json.dumps(socket_event))
                     return
                 time.sleep(0.5)
-            # fallback: graph_task didn't write counts in time — run Neo4j count query below
+            # graph_task didn't write counts within 60s — skip rather than falling back to a
+            # Neo4j count query that can hang and block the chord callback for cypher queries.
+            update_task(annotation_id, "label_count", 1)
+            return
 
         label_count = db_instance.run_query(count_query, None, species)
         count_result = [{}, label_count[0]]

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,3 +4,7 @@ database:
     data_dir: /mnt/hdd_1/biocypher-kg/output/hsa/metta_out_v6
     act_file: human_v6.act
     graph_info_path: ./Data/graph_info.json
+  fly:
+    data_dir: /mnt/hdd_1/biocypher-kg/output/dmel/metta
+    act_file: flybase.act
+    # graph_info_path: ./Data/graph_info.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       MORK_DATA_DIR: ${MORK_DATA_DIR:-/mnt/hdd_1/biocypher-kg/output/hsa/metta_out_v6}
       FLY_MORK_DATA_DIR: ${FLY_MORK_DATA_DIR:-/mnt/hdd_1/biocypher-kg/output/dmel/metta}
       COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:-annotation-query-backend}
+      DEDUP_ENABLED: ${DEDUP_ENABLED:-true}
 
   celery_worker_fast:
     image: "${DOCKER_HUB_REPO}"

--- a/example.env
+++ b/example.env
@@ -1,0 +1,76 @@
+# ──────────────────────────────────────────────
+# Neo4j (Human / HGNC)
+# ──────────────────────────────────────────────
+HUMAN_NEO4J_URI=bolt://your-neo4j-host:7687
+HUMAN_NEO4J_USERNAME=neo4j
+HUMAN_NEO4J_PASSWORD=your_password
+
+# Optional — leave commented out if Drosophila (fly) data is not available.
+# FLY_NEO4J_URI=bolt://your-fly-neo4j-host:7688
+# FLY_NEO4J_USERNAME=neo4j
+# FLY_NEO4J_PASSWORD=your_password
+
+# ──────────────────────────────────────────────
+# MongoDB
+# ──────────────────────────────────────────────
+MONGO_URI=mongodb://localhost:27017/annotation_db
+MONGODB_DOCKER_PORT=27017
+
+# ──────────────────────────────────────────────
+# Redis
+# ──────────────────────────────────────────────
+REDIS_URL=redis://redis:6379/0
+REDIS_URL_BROKER=redis://redis:6379/1
+REDIS_EXPIRATION=3600
+REDIS_DOCKER_PORT=6380
+
+# ──────────────────────────────────────────────
+# Auth
+# ──────────────────────────────────────────────
+JWT_SECRET=your_jwt_secret_here
+SHARED_TOKEN_SECRET=your_shared_token_secret_here
+
+# ──────────────────────────────────────────────
+# LLM / Summary
+# ──────────────────────────────────────────────
+# Supported values: openai, gemini
+LLM_MODEL=openai
+OPENAI_API_KEY=sk-...
+# GEMINI_API_KEY=your_gemini_api_key
+
+# ──────────────────────────────────────────────
+# Elasticsearch (optional)
+# ──────────────────────────────────────────────
+# ES_URL=https://your-elasticsearch-host:9200
+# ES_API_KEY=your_es_api_key
+
+# ──────────────────────────────────────────────
+# MORK / MORK CLI
+# ──────────────────────────────────────────────
+MORK_URL=http://localhost:8080
+MORK_DATA_DIR=/mnt/hdd_1/biocypher-kg/output/hsa/metta_out_v6
+# FLY_MORK_DATA_DIR=/mnt/hdd_1/biocypher-kg/output/dmel/metta
+
+# ──────────────────────────────────────────────
+# Application / Docker
+# ──────────────────────────────────────────────
+APP_PORT=8000
+DOCKER_HUB_REPO=your-dockerhub-username/annotation-query-backend
+COMPOSE_PROJECT_NAME=annotation-query-backend
+
+# Caddy reverse proxy
+CADDY_PORT=80
+CADDY_PORT_FORWARD=8000
+
+# ──────────────────────────────────────────────
+# Feature flags  (shown with their defaults)
+# ──────────────────────────────────────────────
+DEDUP_ENABLED=true
+
+# ──────────────────────────────────────────────
+# Tuning  (shown with their defaults — safe to omit)
+# ──────────────────────────────────────────────
+# TASK_STALE_SECS=2400       # drop tasks older than this many seconds
+# MAX_SLOW_QUEUE=20           # reject slow queries when queue depth >= this
+# MAX_BINDING_VALS=1000       # cap per-variable binding list size in Cypher queries
+# MAX_COMBOS=50000            # cap Cartesian product size in Cypher queries

--- a/example.env
+++ b/example.env
@@ -35,7 +35,7 @@ SHARED_TOKEN_SECRET=your_shared_token_secret_here
 # ──────────────────────────────────────────────
 # Supported values: openai, gemini
 LLM_MODEL=openai
-OPENAI_API_KEY=sk-...
+OPENAI_API_KEY=your_openai_api_key
 # GEMINI_API_KEY=your_gemini_api_key
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
### Summary

This branch addresses a set of interconnected bugs in the Cypher query generator
and annotation pipeline, along with several reliability and observability improvements.

#### Cypher query generation fixes
- Fixed invalid `CALL (var) { }` syntax — replaced with `CALL { WITH var }` which works on all supported versions
- Fixed anchor variable dropping out of scope in inner `WITH` clauses of multi-predicate subqueries, causing silent result truncation

#### Count task deadlock fix
- `total_count_task` and `label_count_task` used flat multi-`MATCH` queries that triggered Cartesian product joins on complex requests (e.g. `child_pathway_of` × `participates_in` × `associated_with`). These would hang indefinitely, blocking `summary_task` from ever firing and leaving annotations stuck in `PENDING`
- Graph counts (`node_count`, `edge_count`, `node_count_by_label`, `edge_count_by_label`) are now computed from the already-serialized graph response in `graph_task` and stored in the Redis cache; count tasks read from there instead of re-querying Neo4j

#### Timing accuracy
- `total_duration` was measured from annotation document creation (before Celery dispatch), inflating it by queue latency; now measured from when `graph_task` begins executing
- Added `summary_duration` to surface LLM summary generation time, which accounts for most of the remaining gap between `retrieval + processing` and `total`

#### Optional fly Neo4j driver
- `CypherQueryGenerator` no longer crashes on startup when `FLY_NEO4J_URI` is unset; the fly driver is skipped with a warning and only fails if a fly-species query is actually attempted

#### `DEDUP_ENABLED` feature flag
- New env var (`DEDUP_ENABLED`, default `true`) allows disabling request deduplication at runtime — useful for debugging without modifying config files

#### example.env
- add example.env configuration file with database and service settings
