### PR TITLE
 feat: Cypher query engine - independent CALL arms + unified result formatter + dmel schema fix  ---

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -75,7 +75,7 @@ def get_schema_manager() -> SchemaManager:
             output_path="./config/human_schema/human_full_schema_config.yaml",
         )
         merge_schemas(
-            primer_schema_path="./config/primer_schema_config.yaml",
+            primer_schema_path="./config/dmel_primer_schema_config.yaml",
             species_schema_path="./config/fly_base_schema/dmel_schema_config.yaml",
             output_path="./config/fly_base_schema/dmel_full_schema_config.yaml",
         )

--- a/app/lib/__init__.py
+++ b/app/lib/__init__.py
@@ -6,3 +6,4 @@ from .auth import token_required
 from .utils import convert_to_excel, generate_file_path, adjust_file_path, extract_middle, convert_to_csv
 from .graph import Graph
 from .heuristic_sort import heuristic_sort
+from .result_formatter import Result_Formatter

--- a/app/lib/db_resilience.py
+++ b/app/lib/db_resilience.py
@@ -234,13 +234,6 @@ class QueryTimeoutConfig:
         return False, None
 
 
-# Default instance – all timeouts are indefinite, no fallbacks.
-# Import and mutate this in your app startup if you want to set limits:
-#
-#   from app.services.db_resilience import DEFAULT_TIMEOUT_CONFIG, QueryType
-#   DEFAULT_TIMEOUT_CONFIG.timeouts[QueryType.COUNT] = 30.0
-#   DEFAULT_TIMEOUT_CONFIG.timeouts[QueryType.GRAPH] = 120.0
-#
 DEFAULT_TIMEOUT_CONFIG = QueryTimeoutConfig()
 
 

--- a/app/lib/db_resilience.py
+++ b/app/lib/db_resilience.py
@@ -237,6 +237,13 @@ class QueryTimeoutConfig:
 DEFAULT_TIMEOUT_CONFIG = QueryTimeoutConfig()
 
 
+# Default instance – all timeouts are indefinite, no fallbacks.
+# Import and mutate this in your app startup if you want to set limits:
+#
+#   from app.services.db_resilience import DEFAULT_TIMEOUT_CONFIG, QueryType
+#   DEFAULT_TIMEOUT_CONFIG.timeouts[QueryType.COUNT] = 30.0
+#   DEFAULT_TIMEOUT_CONFIG.timeouts[QueryType.GRAPH] = 120.0
+
 # 4. Resilient driver
 
 class ResilientDriver:

--- a/app/lib/result_formatter.py
+++ b/app/lib/result_formatter.py
@@ -1,0 +1,342 @@
+"""
+Unified Result Formatter
+
+This module centralizes the processing and formatting of query results from
+various database backends (Neo4j, MeTTa, Mork) into a unified JSON structure
+suitable for the frontend graph visualization.
+NOTE: for now it only tested on neo4j and only being used by neo4j
+"""
+
+from typing import TypedDict, List, Dict, Any, Tuple, Union
+import neo4j
+        
+try:
+    import graph_native as _graph_native
+    _NATIVE_AVAILABLE = True
+except ImportError:
+    _NATIVE_AVAILABLE = False
+
+class LabelCount(TypedDict):
+    label: str
+    count: int
+
+class ProcessedCount(TypedDict):
+    node_count: int
+    edge_count: int
+    node_count_by_label: List[LabelCount]
+    edge_count_by_label: List[LabelCount]
+
+class NodeData(TypedDict):
+    data: Dict[str, Any]
+
+class EdgeData(TypedDict):
+    data: Dict[str, Any]
+
+class UnifiedGraphOutput(TypedDict):
+    nodes: List[NodeData]
+    edges: List[EdgeData]
+
+
+class Result_Formatter:
+    """
+    Formats raw database results into a standardized graph or count representation.
+    """
+
+    NAMED_TYPES = [
+        'gene_name', 'transcript_name', 'protein_name',
+        'pathway_name', 'term_name'
+    ]
+
+    def format_result(self, data: Any, format_type: str, graph_components: Dict[str, Any], result_type: str = 'graph') -> Union[UnifiedGraphOutput, ProcessedCount, Dict[str, Any]]:
+        """
+        Main entry point for formatting database results.
+        
+        Args:
+            data: Raw results from the database.
+            format_type (str): The source database type ('neo4j', 'metta', 'mork').
+            graph_components (dict): Metadata about the requested graph structure.
+            result_type (str): The desired output format ('graph' or 'count').
+            
+        Returns:
+            dict: The formatted result in the unified structure.
+        """
+        if result_type == 'graph':
+            nodes, edges = self._process_graph(data, format_type, graph_components)
+            return self._format_graph_output(nodes, edges)
+
+        elif result_type == 'count':
+            return self._process_count(data, format_type, graph_components)
+
+        return {}
+
+    def _process_graph(self, data: Any, format_type: str, graph_components: Dict[str, Any]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """Routes graph processing to the appropriate database-specific handler."""
+        if format_type == "neo4j":
+            return self._process_neo4j_graph(data, graph_components)
+
+        elif format_type in ["mork", "metta"]:
+            from app.services.metta.metta_seralizer import metta_seralizer
+
+            results = data
+            identifiers = None
+            if isinstance(data, tuple) and len(data) == 2:
+                results, identifiers = data
+
+            tuples = metta_seralizer(results[0]) if isinstance(results, list) and results else []
+
+            if not tuples and identifiers:
+                return self._process_simple_graph(identifiers)
+
+            return self._process_metta_graph(tuples, graph_components)
+
+        raise ValueError(f"Unknown format_type for graph processing: {format_type}")
+
+    def _process_neo4j_graph(self, results, graph_components):
+        
+        if _NATIVE_AVAILABLE:
+            try:
+                out = _graph_native.format_neo4j_graph(results, graph_components)
+                # native already returns {"nodes": [...], "edges": [...]} with data-wrapped dicts
+                return (
+                    [n["data"] for n in out["nodes"]],
+                    [e["data"] for e in out["edges"]],
+                )
+            except Exception as e:
+                print("PROCESS NEO$J GRAPH--------------------------------", flush=True)
+                print(e, flush=True)
+                pass  
+
+        nodes = []
+        node_seen = {}
+        edges = []
+        edge_seen = set()
+
+        properties_enabled = graph_components.get('properties', True)
+
+        named_types_dict = {
+            "gene": "gene_name",
+            "transcript": "transcript_name",
+            "protein": "protein_name",
+            "pathway": "pathway_name",
+            "term": "term_name",
+        }
+
+        def _register_node(item):
+            label = list(item.labels)[0]
+            node_id = f"{label} {item['id']}"
+            if node_id in node_seen:
+                return
+            node_data = {"id": node_id, "type": label}
+            for key, value in item.items():
+                if properties_enabled:
+                    if key not in ("id", "synonyms"):
+                        node_data[key] = value
+                elif key in self.NAMED_TYPES:
+                    node_data["name"] = value
+            if "name" not in node_data:
+                fallback_key = named_types_dict.get(label.lower())
+                if fallback_key and fallback_key in node_data:
+                    node_data["name"] = node_data[fallback_key]
+                else:
+                    node_data["name"] = node_id
+            nodes.append(node_data)
+            node_seen[node_id] = node_data
+
+        def _register_relationship(item):
+            source_label = list(item.start_node.labels)[0]
+            target_label = list(item.end_node.labels)[0]
+            source_id = f"{source_label} {item.start_node['id']}"
+            target_id = f"{target_label} {item.end_node['id']}"
+            sig = f"{source_id} - {item.type} - {target_id}"
+            if sig in edge_seen:
+                return
+            edge_seen.add(sig)
+            edge_data = {
+                "edge_id": f"{source_label}_{item.type}_{target_label}",
+                "label": item.type,
+                "source": source_id,
+                "target": target_id,
+            }
+            for key, value in item.items():
+                edge_data["source_data" if key == "source" else key] = value
+            edges.append(edge_data)
+            # Always register endpoint nodes too
+            _register_node(item.start_node)
+            _register_node(item.end_node)
+
+        for record in results:
+            for item in record.values():
+                if isinstance(item, neo4j.graph.Node):
+                    _register_node(item)
+                elif isinstance(item, neo4j.graph.Relationship):
+                    _register_relationship(item)
+                elif isinstance(item, list):
+                    # CALL subquery path: list of maps {node_var: Node, pred_var: Rel}
+                    for entry in item:
+                        if isinstance(entry, dict):
+                            for val in entry.values():
+                                if isinstance(val, neo4j.graph.Node):
+                                    _register_node(val)
+                                elif isinstance(val, neo4j.graph.Relationship):
+                                    _register_relationship(val)
+                        elif isinstance(entry, neo4j.graph.Node):
+                            _register_node(entry)
+                        elif isinstance(entry, neo4j.graph.Relationship):
+                            _register_relationship(entry)
+
+        return nodes, edges
+
+    def _process_metta_graph(self, tuples: List[Tuple], graph_components: Dict[str, Any]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """Extracts nodes and edges from serialized MeTTa/Mork tuples."""
+        nodes_map = {}
+        rels_map = {}
+
+        properties_enabled = graph_components.get('properties', True)
+
+        for match in tuples:
+            graph_attr = match[0]
+            parts = match[1:]
+
+            if graph_attr == "node":
+                prop = parts[0]
+                src_type = parts[1]
+                src_value = parts[2]
+                target_val = parts[3:]
+
+                node_id = f"{src_type} {src_value}"
+
+                if node_id not in nodes_map:
+                    nodes_map[node_id] = {"id": node_id, "type": src_type}
+
+                if properties_enabled:
+                    nodes_map[node_id][prop] = target_val
+                elif prop in self.NAMED_TYPES:
+                    nodes_map[node_id]['name'] = target_val
+
+                nodes_map[node_id].pop('synonyms', None)
+
+            elif graph_attr == "edge":
+                prop = parts[0]
+                label = parts[1]
+                src_type = parts[2]
+                src_id = parts[3]
+                tgt_type = parts[4]
+                tgt_id = parts[5]
+                val = ' '.join(parts[6:])
+
+                rel_key = (label, src_type, src_id, tgt_type, tgt_id)
+                if rel_key not in rels_map:
+                    rels_map[rel_key] = {
+                        "edge_id": f"{src_type}_{label}_{tgt_type}",
+                        "label": label,
+                        "source": f"{src_type} {src_id}",
+                        "target": f"{tgt_type} {tgt_id}",
+                    }
+
+                rels_map[rel_key]["source_data" if prop == "source" else prop] = val
+
+        return list(nodes_map.values()), list(rels_map.values())
+
+    def _format_graph_output(self, nodes: List[Dict[str, Any]], edges: List[Dict[str, Any]]) -> UnifiedGraphOutput:
+        """Wraps standard node and edge dictionaries into the final unified format."""
+        return {
+            "nodes": [{"data": node} for node in nodes],
+            "edges": [{"data": edge} for edge in edges],
+        }
+
+    def _process_count(self, data: Any, format_type: str, graph_components: Dict[str, Any]) -> ProcessedCount:
+        """Routes count processing to the appropriate database-specific handler."""
+        if format_type == "neo4j":
+            return self._process_neo4j_count(data, graph_components)
+        elif format_type in ["mork", "metta"]:
+            return self._process_metta_mork_count(data)
+
+        raise ValueError(f"Unknown format_type for count processing: {format_type}")
+
+    def _process_neo4j_count(self, results, graph_components):
+        if not results:
+            return {}
+        
+        if _NATIVE_AVAILABLE:
+            try:
+                return _graph_native.format_neo4j_count(results, graph_components)
+            except Exception as e:
+                print("PROCESS NEO4j COUNT------------------------", flush=True)
+                print(e, flush=True)
+                pass  
+
+        node_and_edge_count = results[0]
+        count_by_label = results[1] if len(results) > 1 else {}
+
+        node_count = node_and_edge_count.get('total_nodes', 0) if node_and_edge_count else 0
+        edge_count = node_and_edge_count.get('total_edges', 0) if node_and_edge_count else 0
+
+        node_agg = {n['type']: 0 for n in graph_components.get('nodes', [])}
+        edge_agg = {
+            p['type'].replace(" ", "_").lower(): 0
+            for p in graph_components.get('predicates', [])
+        }
+
+        if count_by_label:
+            for key, value in count_by_label.items():
+                label_key = '_'.join(key.split('_')[1:])
+                if label_key in node_agg:
+                    node_agg[label_key] += value
+                if label_key in edge_agg:
+                    edge_agg[label_key] += value
+
+        return {
+            "node_count": node_count,
+            "edge_count": edge_count,
+            "node_count_by_label": [{'label': k, 'count': v} for k, v in node_agg.items()],
+            "edge_count_by_label": [{'label': k, 'count': v} for k, v in edge_agg.items()],
+        }
+
+    def _process_metta_mork_count(self, results: Any) -> ProcessedCount:
+        """Aggregates node and edge counts from MeTTa/Mork query results."""
+        from app.services.mork import get_total_counts, get_count_by_label
+
+        meta_data = {}
+        if results and results[0]:
+            meta_data.update(get_total_counts(results[0]))
+        if len(results) > 1 and results[1]:
+            meta_data.update(get_count_by_label(results[1]))
+        return meta_data
+
+    def _process_simple_graph(self, results: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """
+        Creates a basic graph structure from identifiers when property fetching yields no results.
+        """
+        nodes_seen = set()
+        nodes = []
+        edges = []
+
+        for result in results:
+            if not result:
+                continue
+
+            source = result.get('source')
+            target = result.get('target')
+            predicate = result.get('predicate')
+
+            for node_id in [source, target]:
+                if node_id and node_id not in nodes_seen:
+                    nodes_seen.add(node_id)
+                    nodes.append({
+                        "id": node_id,
+                        "type": node_id.split(' ')[0],
+                        "name": node_id
+                    })
+
+            if source and target and predicate:
+                source_label = source.split(' ')[0]
+                target_label = target.split(' ')[0]
+                edges.append({
+                    "id": f"{source_label}_{predicate}_{target_label}_{len(edges)}",
+                    "edge_id": f"{source_label}_{predicate}_{target_label}",
+                    "label": predicate,
+                    "source": source,
+                    "target": target,
+                })
+
+        return nodes, edges

--- a/app/lib/result_formatter.py
+++ b/app/lib/result_formatter.py
@@ -100,10 +100,11 @@ class Result_Formatter:
                     [n["data"] for n in out["nodes"]],
                     [e["data"] for e in out["edges"]],
                 )
-            except Exception as e:
-                print("PROCESS NEO$J GRAPH--------------------------------", flush=True)
-                print(e, flush=True)
-                pass  
+            except Exception:
+                import logging
+                logging.getLogger(__name__).exception(
+                    "Native Neo4j graph formatter failed; falling back to Python implementation"
+                )
 
         nodes = []
         node_seen = {}

--- a/app/lib/result_formatter.py
+++ b/app/lib/result_formatter.py
@@ -92,7 +92,6 @@ class Result_Formatter:
         raise ValueError(f"Unknown format_type for graph processing: {format_type}")
 
     def _process_neo4j_graph(self, results, graph_components):
-        
         if _NATIVE_AVAILABLE:
             try:
                 out = _graph_native.format_neo4j_graph(results, graph_components)

--- a/app/lib/result_formatter.py
+++ b/app/lib/result_formatter.py
@@ -260,10 +260,11 @@ class Result_Formatter:
         if _NATIVE_AVAILABLE:
             try:
                 return _graph_native.format_neo4j_count(results, graph_components)
-            except Exception as e:
-                print("PROCESS NEO4j COUNT------------------------", flush=True)
-                print(e, flush=True)
-                pass  
+            except Exception:
+                import logging
+                logging.getLogger(__name__).exception(
+                    "Native Neo4j count formatter failed; falling back to Python implementation"
+                )
 
         node_and_edge_count = results[0]
         count_by_label = results[1] if len(results) > 1 else {}

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -1,16 +1,13 @@
-from typing import List
 import logging
 from dotenv import load_dotenv
-import neo4j
 from app.services.query_generator_interface import QueryGeneratorInterface
-from neo4j import GraphDatabase
 import glob
 import os
-from neo4j.graph import Node, Relationship
-from app.error import TaskCancelledException
 from collections import Counter
-
+import re
 from app.lib.db_resilience import ResilientDriver, RetryPolicy, QueryType, QueryTimeoutConfig
+from app.lib.result_formatter import Result_Formatter
+from collections import deque
 
 load_dotenv()
 
@@ -62,6 +59,8 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             retry_policy=_DEFAULT_POLICY,
             timeout_config=_TIMEOUT_CONFIG,
         )
+        
+        self.formatter = Result_Formatter()
 
     def close(self):
         self.human_driver.close()
@@ -106,17 +105,11 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         # use lazy loading for improved performance
         return driver.run_with_retry(query_code, stop_event=stop_event, query_type=query_type)
 
-    def _find_anchor_node(self, predicates):
-        """
-        Find a node_id that appears in the majority of predicates (as source or
-        target).  This node is matched outside the CALL subquery and scopes the
-        inner aggregations, which keeps memory flat regardless of result size.
-
-        Returns the best anchor node_id, or None if no suitable anchor exists
-        (e.g. fewer than 2 predicates, or a fully disconnected graph pattern).
-        When None is returned the caller falls back to the original multi-MATCH
-        WITH chain.
-        """
+    def _escape_regex(self, value: str) -> str:
+        """Escape regex special characters in a property value."""
+        return re.escape(value)
+    
+    def _find_anchor_node(self, predicates, node_map):
         if not predicates or len(predicates) < 2:
             return None
 
@@ -127,178 +120,173 @@ class CypherQueryGenerator(QueryGeneratorInterface):
 
         n = len(predicates)
 
-        # node present in every predicate
-        full_anchors = [nid for nid, cnt in per_pred.items() if cnt == n]
-        if full_anchors:
-            return full_anchors[0]
+        def has_filter(nid):
+            node = node_map[nid]
+            return bool(node.get('id')) or bool(node.get('properties'))
 
-        # node present in all-but-one predicate (handles star+tail patterns)
-        best_nid, best_cnt = per_pred.most_common(1)[0]
-        if best_cnt >= max(2, n - 1):
+        # First priority: filtered node that appears in most predicates
+        # Sort by: (has_filter DESC, count DESC)
+        ranked = sorted(
+            per_pred.items(),
+            key=lambda x: (1 if has_filter(x[0]) else 0, x[1]),
+            reverse=True
+        )
+
+        best_nid, best_cnt = ranked[0]
+
+        # Only use as anchor if it appears in at least 2 predicates
+        # OR if it's the only filtered node (chain pattern with filter at one end)
+        if best_cnt >= 2:
             return best_nid
+
+        # For chain patterns where no node appears in 2+ predicates,
+        # pick the filtered node even if it appears in only 1 predicate
+        filtered_nodes = [(nid, cnt) for nid, cnt in per_pred.items() if has_filter(nid)]
+        if filtered_nodes:
+            return max(filtered_nodes, key=lambda x: x[1])[0]
 
         return None
 
     def _build_call_subquery(self, predicates, node_map, predicate_map,
-                             anchor_var, limit=None, node_only=False, inner_limit=None):
+                            anchor_var, limit=None, node_only=False, inner_limit=None):
         """
-        Build a CALL-subquery-scoped Cypher query:
+        Build a CALL-subquery-scoped Cypher query using independent CALL arms.
 
-          MATCH (anchor_var:Type) WHERE <anchor conditions>
-          CALL (anchor_var) {
-            MATCH <pred0 pattern> WHERE <pred0 conditions>
-            WITH collect({<non-anchor node>: <var>, <pred_id>: <var>}) AS p0
-            MATCH <pred1 pattern> WHERE <pred1 conditions>
-            WITH p0, collect({...}) AS p1
-            ...
-            RETURN p0, p1, ...
-          }
-          RETURN anchor_var, p0, p1, ...
-          [LIMIT n]
-
-        Each predicate alias (p0, p1 …) is a list of maps so the result is a
-        single row per anchor node instead of a Cartesian product of rows.
-
-        When a non-anchor node was already collected in a previous predicate
-        (e.g. n5 collected in p1 then reused in p4), the method UNWINDs the
-        prior collect to bring that node back into scope rather than doing a
-        free MATCH against all nodes of that type in the database.
+        The anchor node is always matched in the outer MATCH with its own
+        filters. Every predicate goes into an independent CALL arm.
+        This ensures 1 row per anchor node regardless of connection count,
+        and avoids Cartesian product row explosion entirely.
 
         Returns:
-            cypher_str   – the full query string
-            aliases      – list of collect-alias names  (e.g. ['p0','p1',...])
-            outer_nodes  – [anchor_var]
+            cypher_str   - the full query string
+            aliases      - list of collect-alias names per arm
+            outer_nodes  - [anchor_var]
         """
         anchor_node = node_map[anchor_var]
-        anchor_match = self.match_node(anchor_node, anchor_var)
         anchor_where = self.where_construct(anchor_node, anchor_var)
 
-        outer_match = f"MATCH {anchor_match}"
+        # Always use anchor as outer MATCH with its own filters
+        outer_match = f"MATCH {self.match_node(anchor_node, anchor_var)}"
         outer_where = f"WHERE {' AND '.join(anchor_where)}" if anchor_where else ""
 
-        inner_lines = []
-        aliases = []        # collect alias per predicate (same as predicate_id)
-        carried = []        # aliases already collected and carried forward
+        # All predicates go into independent CALL arms
+        remaining_predicates = predicates
 
-        # Track which non-anchor node vars have been collected and in which alias
-        # key: node_var, value: (alias, key_in_map) e.g. ('p1', 'n5')
-        collected_nodes = {}
+        # Group predicates into independent arms.
+        # An arm starts with a predicate touching the anchor.
+        # It then greedily pulls in ALL predicates that touch any node
+        # already in the arm (multi-branch chains like transcript->pathway
+        # AND transcript->protein both get pulled into the same arm).
+        # Predicates with NO connection to anchor go into their own arm.
+        arms = []
+        assigned = set()
 
-        for i, predicate in enumerate(predicates):
-            pred_id   = predicate['predicate_id']
-            pred_type = predicate['type'].replace(' ', '_').lower()
-            source_var = predicate['source']
-            target_var = predicate['target']
-            source_node = node_map[source_var]
-            target_node = node_map[target_var]
+        for pred in remaining_predicates:
+            if pred['predicate_id'] in assigned:
+                continue
+            src = pred['source']
+            tgt = pred['target']
 
-            is_virtual = (pred_type == 'overlaps_with')
+            arm = [pred]
+            assigned.add(pred['predicate_id'])
 
-            # Determine which end(s) of this predicate need to be unwound
-            # because they were already collected in a previous step
-            unwind_lines = []
-            needs_unwind_source = (
-                source_var != anchor_var and
-                source_var in collected_nodes
-            )
-            needs_unwind_target = (
-                target_var != anchor_var and
-                target_var in collected_nodes
-            )
+            # Collect all nodes introduced by this arm so far
+            arm_nodes = {src, tgt}
 
-            if needs_unwind_source:
-                prev_alias, prev_key = collected_nodes[source_var]
-                unwind_lines.append(f"  UNWIND [x IN {prev_alias} | x.{prev_key}] AS {source_var}")
-            if needs_unwind_target:
-                prev_alias, prev_key = collected_nodes[target_var]
-                unwind_lines.append(f"  UNWIND [x IN {prev_alias} | x.{prev_key}] AS {target_var}")
+            # Greedily pull in any unassigned predicate that shares a node
+            # with the current arm — repeat until no more can be added
+            changed = True
+            while changed:
+                changed = False
+                for next_pred in remaining_predicates:
+                    if next_pred['predicate_id'] in assigned:
+                        continue
+                    ns = next_pred['source']
+                    nt = next_pred['target']
+                    # Only pull in if it connects to a non-anchor arm node
+                    # (prevents pulling in unrelated predicates that only
+                    # share the anchor — those get their own arm)
+                    non_anchor_arm_nodes = arm_nodes - {anchor_var}
+                    if ns in non_anchor_arm_nodes or nt in non_anchor_arm_nodes:
+                        arm.append(next_pred)
+                        assigned.add(next_pred['predicate_id'])
+                        arm_nodes.add(ns)
+                        arm_nodes.add(nt)
+                        changed = True
 
-            # Build MATCH pattern — skip re-declaring the anchor node
-            # and skip re-declaring nodes that were just unwound (they are already in scope)
-            source_match_str = self.match_node(source_node, source_var)
-            target_match_str = self.match_node(target_node, target_var)
+            arms.append(arm)
+        # Build independent CALL arms
+        call_blocks = []
+        all_aliases = []
 
-            if source_var == anchor_var:
-                match_pattern = f"MATCH ({anchor_var})-[{pred_id}:{pred_type}]->{target_match_str}"
-            elif target_var == anchor_var:
-                match_pattern = f"MATCH {source_match_str}-[{pred_id}:{pred_type}]->({anchor_var})"
-            elif needs_unwind_source and not needs_unwind_target:
-                # source already in scope via UNWIND — only declare target
-                match_pattern = f"MATCH ({source_var})-[{pred_id}:{pred_type}]->{target_match_str}"
-            elif needs_unwind_target and not needs_unwind_source:
-                # target already in scope via UNWIND — only declare source
-                match_pattern = f"MATCH {source_match_str}-[{pred_id}:{pred_type}]->({target_var})"
-            elif needs_unwind_source and needs_unwind_target:
-                # both already in scope
-                match_pattern = f"MATCH ({source_var})-[{pred_id}:{pred_type}]->({target_var})"
-            else:
-                match_pattern = f"MATCH {source_match_str}-[{pred_id}:{pred_type}]->{target_match_str}"
+        for arm in arms:
+            arm_pred_ids = [p['predicate_id'] for p in arm]
+            arm_alias = '_'.join(arm_pred_ids)
 
-            # WHERE conditions — only for non-anchor, non-unwound nodes
-            where_parts = []
-            overlap_parts = self.construct_overlap_clause(source_var, target_var, pred_type)
-            if overlap_parts:
-                where_parts.extend(overlap_parts)
-            for var in [source_var, target_var]:
-                if var != anchor_var and var not in collected_nodes:
-                    where_parts.extend(self.where_construct(node_map[var], var))
-            where_clause = f"WHERE {' AND '.join(where_parts)}" if where_parts else ""
-
-            # Virtual relationship creation (overlaps_with)
-            virtual_creation = ""
-            if is_virtual:
-                virtual_creation = (
-                    f"WITH *, apoc.create.vRelationship({source_var}, '{pred_type}', "
-                    f"{{source:'virtual'}}, {target_var}) AS {pred_id}"
-                )
-
-            # collect() map — include non-anchor node(s) and the relationship
+            match_lines = []
+            where_lines = []
             map_entries = {}
-            for var in [source_var, target_var]:
-                if var != anchor_var:
-                    map_entries[var] = var
-            map_entries[pred_id] = pred_id
+            seen_in_arm = {anchor_var}
+
+            for pred in arm:
+                pred_id = pred['predicate_id']
+                pred_type = pred['type'].replace(' ', '_').lower()
+                src = pred['source']
+                tgt = pred['target']
+                src_node = node_map[src]
+                tgt_node = node_map[tgt]
+
+                src_match_str = self.match_node(src_node, src)
+                tgt_match_str = self.match_node(tgt_node, tgt)
+
+                # Build MATCH pattern
+                if src == anchor_var:
+                    match_lines.append(f"  MATCH ({anchor_var})-[{pred_id}:{pred_type}]->{tgt_match_str}")
+                elif tgt == anchor_var:
+                    match_lines.append(f"  MATCH {src_match_str}-[{pred_id}:{pred_type}]->({anchor_var})")
+                elif src in seen_in_arm:
+                    match_lines.append(f"  MATCH ({src})-[{pred_id}:{pred_type}]->{tgt_match_str}")
+                elif tgt in seen_in_arm:
+                    match_lines.append(f"  MATCH {src_match_str}-[{pred_id}:{pred_type}]->({tgt})")
+                else:
+                    match_lines.append(f"  MATCH {src_match_str}-[{pred_id}:{pred_type}]->{tgt_match_str}")
+
+                # WHERE conditions for new nodes introduced in this arm
+                where_parts = []
+                for var in [src, tgt]:
+                    if var != anchor_var and var not in seen_in_arm:
+                        conds = self.where_construct(node_map[var], var)
+                        if conds:
+                            where_parts.extend(conds)
+                        seen_in_arm.add(var)
+
+                if where_parts:
+                    match_lines.append(f"  WHERE {' AND '.join(where_parts)}")
+
+                # Add non-anchor vars and relationship to collect map
+                for var in [src, tgt]:
+                    if var != anchor_var:
+                        map_entries[var] = var
+                map_entries[pred_id] = pred_id
+
+            # Build collect expression
             collect_map = '{' + ', '.join(f"{k}: {v}" for k, v in map_entries.items()) + '}'
-            if inner_limit:
-                collect_expr = f"[x IN collect({collect_map}) | x][0..{inner_limit}] AS {pred_id}"
-            else:
-                collect_expr = f"collect({collect_map}) AS {pred_id}"
+            collect_expr = f"collect(DISTINCT {collect_map}) AS {arm_alias}"
 
-            aliases.append(pred_id)
+            inner_lines = match_lines + [f"  RETURN {collect_expr}"]
+            call_block = f"CALL ({anchor_var}) {{\n" + '\n'.join(inner_lines) + "\n}"
+            call_blocks.append(call_block)
+            all_aliases.append(arm_alias)
 
-            # Register newly seen non-anchor nodes as collected under this alias
-            for var in [source_var, target_var]:
-                if var != anchor_var and var not in collected_nodes:
-                    collected_nodes[var] = (pred_id, var)
-
-            # Emit UNWIND lines first (bring previously collected nodes back into scope)
-            for ul in unwind_lines:
-                inner_lines.append(ul)
-
-            inner_lines.append(f"  {match_pattern}")
-            if where_clause:
-                inner_lines.append(f"  {where_clause}")
-            if virtual_creation:
-                inner_lines.append(f"  {virtual_creation}")
-
-            # WITH inside CALL — carry prior aliases then add new collect
-            carry_str = ', '.join(carried) + (', ' if carried else '') + collect_expr
-            inner_lines.append(f"  WITH {carry_str}")
-
-            carried.append(pred_id)
-
-        # Final RETURN inside CALL
-        inner_lines.append(f"  RETURN {', '.join(aliases)}")
-
-        call_block = "CALL ({}) {{\n{}\n}}".format(anchor_var, '\n'.join(inner_lines))
-
-        outer_return = f"RETURN {anchor_var}, {', '.join(aliases)}"
+        # Build outer RETURN — anchor + all arm aliases
+        outer_return = f"RETURN {anchor_var}, {', '.join(all_aliases)}"
         limit_clause = f"LIMIT {limit}" if limit else ""
 
-        parts = [p for p in [outer_match, outer_where, call_block, outer_return, limit_clause] if p.strip()]
+        parts = [outer_match, outer_where] + call_blocks + [outer_return, limit_clause]
+        parts = [p for p in parts if p.strip()]
         cypher_str = '\n'.join(parts)
 
-        return cypher_str, aliases, [anchor_var]
+        return cypher_str, all_aliases, [anchor_var]
 
     def query_Generator(self, requests, node_map, limit=None, node_only=False):
         if self.is_in_list_request(requests):
@@ -366,7 +354,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
 
         else:
             # Try CALL subquery pattern first — avoids Cartesian product row explosion
-            anchor_var = self._find_anchor_node(predicates)
+            anchor_var = self._find_anchor_node(predicates, node_map=node_map)
 
             if anchor_var is not None:
                 cypher_query, aliases, outer_nodes = self._build_call_subquery(
@@ -623,6 +611,80 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                 if isinstance(val, str) and ',' in val:
                     return True
         return False
+    
+    def _topological_sort_predicates(self, predicates, list_vars):
+        """
+        Reorders predicates so that every node is matched before it is
+        referenced in a WHERE filter. List nodes must be introduced via a
+        MATCH before their list filter can be applied.
+        """
+
+        pred_ids = [p['predicate_id'] for p in predicates]
+        pred_map = {p['predicate_id']: p for p in predicates}
+
+        # Find which predicate first introduces each node as a target
+        # A node is only truly "introduced" when it appears as a target
+        # in a MATCH — being a source doesn't introduce it
+        target_introducer = {}   # node_var -> pred_id that matches it as target
+        source_introducer = {}   # node_var -> pred_id that uses it as source
+
+        for pred in predicates:
+            src = pred['source']
+            tgt = pred['target']
+            if tgt not in target_introducer:
+                target_introducer[tgt] = pred['predicate_id']
+            if src not in source_introducer:
+                source_introducer[src] = pred['predicate_id']
+
+        # Build dependency graph
+        # dep[pred_id] = set of pred_ids that must come before it
+        dep = {pid: set() for pid in pred_ids}
+
+        for pred in predicates:
+            pred_id = pred['predicate_id']
+            src = pred['source']
+            tgt = pred['target']
+
+            # If source is a list node and was introduced as a target
+            # in another predicate, that predicate must come first
+            if src in list_vars and src in target_introducer:
+                introducer = target_introducer[src]
+                if introducer != pred_id:
+                    dep[pred_id].add(introducer)
+
+            # If target is a list node and was introduced as a target
+            # in another predicate, that predicate must come first
+            if tgt in list_vars and tgt in target_introducer:
+                introducer = target_introducer[tgt]
+                if introducer != pred_id:
+                    dep[pred_id].add(introducer)
+
+            # If source was already seen as a target in another predicate
+            # that predicate must come first
+            if src in target_introducer:
+                introducer = target_introducer[src]
+                if introducer != pred_id:
+                    dep[pred_id].add(introducer)
+
+        # Kahn's algorithm
+        in_degree = {pid: len(deps) for pid, deps in dep.items()}
+        queue = deque(sorted([pid for pid, d in in_degree.items() if d == 0]))
+        sorted_pred_ids = []
+
+        while queue:
+            pid = queue.popleft()
+            sorted_pred_ids.append(pid)
+            for other_pid in pred_ids:
+                if pid in dep[other_pid]:
+                    in_degree[other_pid] -= 1
+                    if in_degree[other_pid] == 0:
+                        queue.append(other_pid)
+
+        # If cycle detected fall back to original order
+        if len(sorted_pred_ids) != len(predicates):
+            return predicates
+
+        return [pred_map[pid] for pid in sorted_pred_ids]
 
     def in_list_query_generator(self, requests, limit=None):
         nodes = requests['nodes']
@@ -635,22 +697,43 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         for idx, pred in enumerate(predicates):
             if 'predicate_id' not in pred:
                 pred['predicate_id'] = f'p{idx}'
-
+                
         node_map = {n['node_id']: n for n in nodes}
 
+        # named_types mirrors parse_id logic — used to detect gene_name vs id
+        named_types = {"gene": "gene_name", "transcript": "transcript_name"}
+        ensembl_prefixes = ["ENSG", "ENST", "FBT", "FBG"]
+
+        def get_list_prop(node, id_list):
+            """
+            Determines which property to filter on for a list node.
+            - If values look like Ensembl IDs → use 'id'
+            - If node type is in named_types → use gene_name / transcript_name
+            - Otherwise fall back to 'id'
+            """
+            if not id_list:
+                return 'id'
+            sample = str(id_list[0]).upper()
+            if any(sample.startswith(p) for p in ensembl_prefixes):
+                return 'id'
+            return named_types.get(node['type'], 'id')
+
         # Build list variables for WITH clause — only for list nodes
-        list_vars = {}
+        list_vars = {}   # var_name -> (id_list, list_var_name, filter_prop)
         list_counter = 0
         for node in nodes:
             var_name = node['node_id']
             if isinstance(node.get('ids'), list) and len(node['ids']) > 0:
-                list_var = f"list{chr(65 + list_counter)}"  # listA, listB, listC ...
-                list_vars[var_name] = (node['ids'], list_var)
+                id_list = node['ids']
+                list_var = f"list{chr(65 + list_counter)}"
+                filter_prop = get_list_prop(node, id_list)
+                list_vars[var_name] = (id_list, list_var, filter_prop)
                 list_counter += 1
             elif node.get('id', '') and ',' in node.get('id', ''):
                 id_list = [i.strip().upper() for i in node['id'].split(',')]
                 list_var = f"list{chr(65 + list_counter)}"
-                list_vars[var_name] = (id_list, list_var)
+                filter_prop = get_list_prop(node, id_list)
+                list_vars[var_name] = (id_list, list_var, filter_prop)
                 list_counter += 1
             else:
                 props = node.get('properties', {})
@@ -658,18 +741,19 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                     if prop_val and isinstance(prop_val, str) and ',' in prop_val:
                         id_list = [i.strip() for i in prop_val.split(',')]
                         list_var = f"list{chr(65 + list_counter)}"
-                        list_vars[var_name] = (id_list, list_var)
+                        list_vars[var_name] = (id_list, list_var, prop_key)
                         list_counter += 1
                         break
-
+        
+        predicates = self._topological_sort_predicates(predicates, list_vars)
         # WITH clause — only list variables
-        with_parts = [f"{id_list} AS {list_var}" for (id_list, list_var) in list_vars.values()]
+        with_parts = [f"{id_list} AS {list_var}" for (id_list, list_var, _) in list_vars.values()]
         with_clause = f"WITH {', '.join(with_parts)}" if with_parts else ""
 
         def get_node_filter(node, var_name):
             """
             Returns WHERE conditions for a node:
-            - list node: var.id IN listX
+            - list node: var.prop IN listX (prop detected via get_list_prop)
             - single id node: already in MATCH clause, no extra WHERE needed
             - property node: var.prop =~ value
             """
@@ -677,19 +761,8 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             conditions = []
 
             if var_name in list_vars:
-                _, list_var = list_vars[var_name]
-                # determine which property to filter on
-                raw_id = node.get('id', '')
-                if raw_id and ',' in raw_id:
-                    conditions.append(f"{var_name}.id IN {list_var}")
-                elif isinstance(node.get('ids'), list):
-                    conditions.append(f"{var_name}.id IN {list_var}")
-                else:
-                    props = node.get('properties', {})
-                    for prop_key, prop_val in props.items():
-                        if prop_val and isinstance(prop_val, str) and ',' in prop_val:
-                            conditions.append(f"{var_name}.{prop_key} IN {list_var}")
-                            break
+                _, list_var, filter_prop = list_vars[var_name]
+                conditions.append(f"{var_name}.{filter_prop} IN {list_var}")
 
             # Additional property filters (non-list, non-reserved)
             props = node.get('properties', {})
@@ -707,11 +780,10 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         def get_match_node(node, var_name):
             """
             Returns MATCH node pattern.
-            - single id: (var:Type {id: 'value'})
+            - single non-comma id: (var:Type {id: 'value'})
             - list or property node: (var:Type)
             """
             raw_id = node.get('id', '')
-            # single non-comma id
             if raw_id and ',' not in raw_id:
                 return f"({var_name}:{node['type']} {{id: '{raw_id}'}})"
             return f"({var_name}:{node['type']})"
@@ -739,14 +811,16 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                 f"{target_match}"
             )
 
-            # Collect WHERE conditions for new nodes only
+            # Collect WHERE conditions only for nodes being introduced for the first time
             tmp_conditions = []
             if source_var not in all_node_vars:
-                tmp_conditions.extend(get_node_filter(source_node, source_var))
-                all_where_conditions.extend(get_node_filter(source_node, source_var))
+                filters = get_node_filter(source_node, source_var)
+                tmp_conditions.extend(filters)
+                all_where_conditions.extend(filters)
             if target_var not in all_node_vars:
-                tmp_conditions.extend(get_node_filter(target_node, target_var))
-                all_where_conditions.extend(get_node_filter(target_node, target_var))
+                filters = get_node_filter(target_node, target_var)
+                tmp_conditions.extend(filters)
+                all_where_conditions.extend(filters)
 
             all_node_vars.add(source_var)
             all_node_vars.add(target_var)
@@ -756,8 +830,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
 
             if i < len(predicates) - 1:
                 # Carry forward list vars + all seen node vars + pred vars so far
-                carry = list(list_vars.values())
-                carry_parts = [lv for (_, lv) in carry]
+                carry_parts = [lv for (_, lv, _) in list_vars.values()]
                 with_parts_chain = carry_parts + all_pred_vars + sorted(all_node_vars)
                 with_chain = f"WITH {', '.join(with_parts_chain)}"
                 clause_list.append(f"{match_pattern} {where_clause} {with_chain}")
@@ -881,7 +954,8 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         for key, value in node['properties'].items():
             if key in ['start', 'end', 'interval_type', 'upstream_distance', 'downstream_distance']:
                 continue
-            properties.append(f"{var_name}.{key} =~ '(?i){value}'")
+            escaped = self._escape_regex(value)
+            properties.append(f"{var_name}.{key} =~ '(?i){escaped}'")
     
         # Interval logic with start and end
         if start is not None and end is not None:
@@ -910,222 +984,18 @@ class CypherQueryGenerator(QueryGeneratorInterface):
     
         return properties
 
-    def parse_neo4j_results(self, results, graph_components, result_type):
-        (nodes, edges, _, _, meta_data) = self.process_result(
-            results, graph_components, result_type)
-        return {"nodes": nodes, "edges": edges,
-                "node_count": meta_data.get('node_count', 0),
-                "edge_count": meta_data.get('edge_count', 0),
-                "node_count_by_label": meta_data.get('node_count_by_label', []),
-                "edge_count_by_label": meta_data.get('edge_count_by_label', [])
-                }
-
     def parse_and_serialize(self, input, schema, graph_components, result_type):
-        parsed_result = self.parse_neo4j_results(
-            input, graph_components, result_type)
-        return parsed_result
+        return self.formatter.format_result(input, "neo4j", graph_components, result_type)
 
     def convert_to_dict(self, results, schema, graph_components):
         graph_components['properties'] = True
-        (_, _, node_dict, edge_dict, _) = self.process_result(
-            results, graph_components)
-        return (node_dict, edge_dict)
-
-    def process_result_graph(self, results, graph_components):
-        node_dict = {}
-        visited_relations = set()
-        nodes = []
-        edges = []
-        node_dict = {}
-        node_to_dict = {}
-        edge_to_dict = {}
-        node_type = set()
-        edge_type = set()
-
-        named_types = ['gene_name', 'transcript_name',
-                       'protein_name', 'pathway_name', 'term_name']
-        
-        named_types_dict = {
-            "gene": "gene_name",
-            "transcript": "transcript_name",
-            "protein": "protein_name",
-            "pathway": "pathway_name",
-            "term": "term_name"
-        }
-
-        def _process_node(item):
-            """Extract and register a neo4j Node into nodes/node_dict."""
-            node_id = f"{list(item.labels)[0]} {item['id']}"
-            if node_id not in node_dict:
-                node_data = {
-                    "data": {
-                        "id": node_id,
-                        "type": list(item.labels)[0],
-                    }
-                }
-                for key, value in item.items():
-                    if graph_components['properties']:
-                        if key != "id" and key != "synonyms":
-                            node_data["data"][key] = value
-                    else:
-                        if key in named_types:
-                            node_data["data"]["name"] = value
-                if "name" not in node_data["data"]:
-                    if named_types_dict.get(node_data["data"]["type"].lower()):
-                        node_data["data"]["name"] = node_data["data"][named_types_dict[node_data["data"]["type"].lower()]]
-                    else:
-                        node_data["data"]["name"] = node_data["data"]["id"]
-                nodes.append(node_data)
-                if node_data["data"]["type"] not in node_type:
-                    node_type.add(node_data["data"]["type"])
-                    node_to_dict[node_data['data']['type']] = []
-                node_to_dict[node_data['data']['type']].append(node_data)
-                node_dict[node_id] = node_data
-
-        def _process_relationship(item):
-            """Extract and register a neo4j Relationship into edges."""
-            source_label = list(item.start_node.labels)[0]
-            target_label = list(item.end_node.labels)[0]
-            source_id = f"{list(item.start_node.labels)[0]} {item.start_node['id']}"
-            target_id = f"{list(item.end_node.labels)[0]} {item.end_node['id']}"
-            edge_data = {
-                "data": {
-                    # "id": item.id,
-                    "edge_id": f"{source_label}_{item.type}_{target_label}",
-                    "label": item.type,
-                    "source": source_id,
-                    "target": target_id,
-                }
-            }
-            temp_relation_id = f"{source_id} - {item.type} - {target_id}"
-            if temp_relation_id in visited_relations:
-                return
-            visited_relations.add(temp_relation_id)
-            for key, value in item.items():
-                if key == 'source':
-                    edge_data["data"]["source_data"] = value
-                else:
-                    edge_data["data"][key] = value
-            edges.append(edge_data)
-            if edge_data["data"]["label"] not in edge_type:
-                edge_type.add(edge_data["data"]["label"])
-                edge_to_dict[edge_data['data']['label']] = []
-            edge_to_dict[edge_data['data']['label']].append(edge_data)
-
-        for record in results:
-            for item in record.values():
-                if isinstance(item, neo4j.graph.Node):
-                    # Direct node in record (flat query or no-predicate query)
-                    _process_node(item)
-                elif isinstance(item, neo4j.graph.Relationship):
-                    # Direct relationship in record (flat query)
-                    _process_relationship(item)
-                    # Also process its endpoint nodes
-                    _process_node(item.start_node)
-                    _process_node(item.end_node)
-                elif isinstance(item, list):
-                    # CALL subquery result: list of maps [{node_var: Node, pred_var: Rel}, ...]
-                    for entry in item:
-                        if isinstance(entry, dict):
-                            for val in entry.values():
-                                if isinstance(val, neo4j.graph.Node):
-                                    _process_node(val)
-                                elif isinstance(val, neo4j.graph.Relationship):
-                                    _process_relationship(val)
-                                    _process_node(val.start_node)
-                                    _process_node(val.end_node)
-                        elif isinstance(entry, neo4j.graph.Node):
-                            _process_node(entry)
-                        elif isinstance(entry, neo4j.graph.Relationship):
-                            _process_relationship(entry)
-                            _process_node(entry.start_node)
-                            _process_node(entry.end_node)
-
-        return (nodes, edges, node_to_dict, edge_to_dict)
-
-    def process_result_count(self, node_and_edge_count, count_by_label, graph_components):
-        node_count_by_label = []
-        edge_count_by_label = []
-        node_count = 0
-        edge_count = 0
-
-        node_count += node_and_edge_count.get('total_nodes', 0)
-        edge_count += node_and_edge_count.get('total_edges', 0)
-        # build edge type set
-        node_count_aggregate = {}
-        ege_count_aggregate = {}
-
-        if len(count_by_label) != 0:
-            # initialize node count aggreate dictionary where the key is the label.
-            for node in graph_components['nodes']:
-                node_type = node['type']
-                node_count_aggregate[node_type] = {'count': 0}
-
-            # initialize edge count aggreate dictionary where the key is the label.
-            for predicate in graph_components['predicates']:
-                edge_type = predicate['type'].replace(" ", "_").lower()
-                ege_count_aggregate[edge_type] = {'count': 0}
-
-            # update node count aggregate dictionary with the count of each label
-            for key, value in count_by_label.items():
-                node_type_key = '_'.join(key.split('_')[1:])
-                if node_type_key in node_count_aggregate:
-                    node_count_aggregate[node_type_key]['count'] += value
-
-            # update edge count aggregate dictionary with the count of each label
-            for key, value in count_by_label.items():
-                edge_type_key = '_'.join(key.split('_')[1:])
-                if edge_type_key in ege_count_aggregate:
-                    ege_count_aggregate[edge_type_key]['count'] += value
-
-            # update the way node count by label and edge count by label are represented
-            for key, value in node_count_aggregate.items():
-                node_count_by_label.append(
-                    {'label': key, 'count': value['count']})
-
-            for key, value in ege_count_aggregate.items():
-                edge_count_by_label.append(
-                    {'label': key, 'count': value['count']})
-
-        meta_data = {
-            "node_count": node_count,
-            "edge_count": edge_count,
-            "node_count_by_label": node_count_by_label,
-            "edge_count_by_label": edge_count_by_label
-        }
-
-        return meta_data
-
-    def process_result(self, results, graph_components, result_type):
-        match_result = results
-        node_and_edge_count = {}
-        count_by_label = {}
-        nodes = []
-        edges = []
-        node_to_dict = {}
-        edge_to_dict = {}
-        meta_data = {}
-
-        if len(results) > 0:
-            node_and_edge_count = results[0]
-
-        if len(results) > 1:
-            count_by_label = results[1]
-
-        if result_type == 'graph':
-            nodes, edges, node_to_dict, edge_to_dict = self.process_result_graph(
-                match_result, graph_components)
-
-        if result_type == 'count':
-            meta_data = self.process_result_count(
-                node_and_edge_count, count_by_label, graph_components)
-
-        return (nodes, edges, node_to_dict, edge_to_dict, meta_data)
+        res = self.formatter.format_result(results, "neo4j", graph_components, result_type='graph')
+        return (res['nodes'], res['edges'])
 
     def parse_id(self, request):
         nodes = request["nodes"]
         named_types = {"gene": "gene_name", "transcript": "transcript_name"}
-        prefixes = ["ENSG", "ENST"]
+        prefixes = ["ENSG", "ENST", "FBT", "FBG"]
 
         for node in nodes:
             is_named_type = node['type'] in named_types

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -115,9 +115,9 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             driver = self.human_driver
         return driver.run_with_retry(query_code, stop_event=stop_event, query_type=query_type)
 
-    def _escape_regex(self, value: str) -> str:
+    def _escape_regex(self, value) -> str:
         """Escape regex special characters in a property value."""
-        return re.escape(value)
+        return re.escape(str(value))
     
     def _find_anchor_node(self, predicates, node_map):
         if not predicates or len(predicates) < 2:

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -158,7 +158,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         return None
 
     def _build_call_subquery(self, predicates, node_map, predicate_map,
-                            anchor_var, limit=None, node_only=False, inner_limit=None):
+                            anchor_var, limit=None, node_only=False, inner_limit=None, strict=True):
         """
         Build a CALL-subquery-scoped Cypher query using independent CALL arms.
 
@@ -225,6 +225,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                         changed = True
 
             arms.append(arm)
+
         # Build independent CALL arms
         call_blocks = []
         all_aliases = []
@@ -234,7 +235,6 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             arm_alias = '_'.join(arm_pred_ids)
 
             match_lines = []
-            where_lines = []
             map_entries = {}
             seen_in_arm = {anchor_var}
 
@@ -292,7 +292,13 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         outer_return = f"RETURN {anchor_var}, {', '.join(all_aliases)}"
         limit_clause = f"LIMIT {limit}" if limit else ""
 
-        parts = [outer_match, outer_where] + call_blocks + [outer_return, limit_clause]
+        # strict=True (default): all arms must return data, otherwise the whole
+        # result is empty. strict=False: return partial results even if some arms
+        # have no data.
+        size_checks = ' AND '.join(f"size({alias}) > 0" for alias in all_aliases)
+        strict_where = f"WITH * WHERE {size_checks}" if strict else ""
+
+        parts = [outer_match, outer_where] + call_blocks + [strict_where, outer_return, limit_clause]
         parts = [p for p in parts if p.strip()]
         cypher_str = '\n'.join(parts)
 

--- a/app/services/llm_handler.py
+++ b/app/services/llm_handler.py
@@ -326,7 +326,7 @@ class LLMHandler:
                 "t_generic": t_generic,
             })
 
-        # --- STEP 1: Group similar fragments ---
+        # Group similar fragments
         # Key: (verb, t_text) — fragments that share the same verb and target
         # are grouped and their source labels are merged
         from collections import OrderedDict
@@ -369,7 +369,7 @@ class LLMHandler:
                 # Single source — use original fragment
                 result_fragments.append(g['fragment'])
 
-        # --- STEP 2: Deduplicate exact repeated fragments ---
+        # Deduplicate exact repeated fragments
         seen = []
         deduped = []
         for f in result_fragments:

--- a/app/services/llm_handler.py
+++ b/app/services/llm_handler.py
@@ -189,7 +189,24 @@ class LLMHandler:
 
         n_type = node.get('type', 'entity').replace('_', ' ').title()
         props = node.get('properties', {})
-        
+
+        # Handle list nodes — return a short label with count instead of listing all values
+        if isinstance(node.get('ids'), list) and len(node['ids']) > 0:
+            count = len(node['ids'])
+            return f"{count} {n_type}s", True
+
+        # Handle comma-separated id field (alternative list format)
+        raw_id = node.get('id', '')
+        if isinstance(raw_id, str) and ',' in raw_id:
+            count = len([i for i in raw_id.split(',') if i.strip()])
+            return f"{count} {n_type}s", True
+
+        # Handle comma-separated property values (another alternative list format)
+        for val in props.values():
+            if isinstance(val, str) and ',' in val:
+                count = len([i for i in val.split(',') if i.strip()])
+                return f"{count} {n_type}s", True
+
         def clean_val(value, key_name):
             """
             Cleans database values:
@@ -256,7 +273,6 @@ class LLMHandler:
     def generate_title_no_llm(self, req, node_map):
         predicates = req.get('predicates', [])
 
-
         if not predicates:
             # List items, adding "Unnamed" if generic
             items = []
@@ -285,14 +301,11 @@ class LLMHandler:
             if s_generic and t_generic and s_text == t_text:
                 fragment = f"a {s_text} {verb} another {t_text}"
             
-            # Scenario 2: "IGF1 in TAD region Tad" (Specific -> Generic Same Type redundancy)
-            # We fix this by removing the target label if it repeats the verb context
-            # e.g. "in tad region" + "Tad" -> just "is in a TAD region"
+            # Scenario 2: target label repeats the verb context
             elif t_generic and t_text.lower() in verb.lower():
-                 fragment = f"{s_text} {verb}"
+                fragment = f"{s_text} {verb}"
             
             # Scenario 3: "IGF1 child of Pathway" (Specific -> Generic)
-            # Add "a" or "an" to make it read naturally
             elif t_generic:
                 fragment = f"{s_text} {verb} a {t_text}"
                 
@@ -304,10 +317,68 @@ class LLMHandler:
             else:
                 fragment = f"{s_text} {verb} {t_text}"
 
-            chains.append(fragment)
+            chains.append({
+                "fragment": fragment,
+                "s_text": s_text,
+                "t_text": t_text,
+                "verb": verb,
+                "s_generic": s_generic,
+                "t_generic": t_generic,
+            })
+
+        # --- STEP 1: Group similar fragments ---
+        # Key: (verb, t_text) — fragments that share the same verb and target
+        # are grouped and their source labels are merged
+        from collections import OrderedDict
+        grouped = OrderedDict()
+        exact_fragments = []  # track final fragment strings for dedup in step 2
+
+        for c in chains:
+            group_key = (c['verb'], c['t_text'])
+
+            if group_key not in grouped:
+                grouped[group_key] = {
+                    "sources": [c['s_text']],
+                    "verb": c['verb'],
+                    "t_text": c['t_text'],
+                    "t_generic": c['t_generic'],
+                    "fragment": c['fragment'],  # fallback if only one source
+                }
+            else:
+                # Only group if source is different — avoid grouping identical fragments
+                if c['s_text'] not in grouped[group_key]['sources']:
+                    grouped[group_key]['sources'].append(c['s_text'])
+
+        # Build grouped fragment strings
+        result_fragments = []
+        for key, g in grouped.items():
+            sources = g['sources']
+            verb = g['verb']
+            t_text = g['t_text']
+            t_generic = g['t_generic']
+
+            if len(sources) > 1:
+                # Merge sources: "15, 7 and 4 Genes transcribe to a Transcript"
+                source_str = ', '.join(sources[:-1]) + f" and {sources[-1]}"
+                if t_generic:
+                    merged = f"{source_str} {verb} a {t_text}"
+                else:
+                    merged = f"{source_str} {verb} {t_text}"
+                result_fragments.append(merged)
+            else:
+                # Single source — use original fragment
+                result_fragments.append(g['fragment'])
+
+        # --- STEP 2: Deduplicate exact repeated fragments ---
+        seen = []
+        deduped = []
+        for f in result_fragments:
+            if f not in seen:
+                seen.append(f)
+                deduped.append(f)
 
         # Final Polish
-        title = ", and ".join(chains)
+        title = ", ".join(deduped)
         return title[0].upper() + title[1:]
 
     def generate_summary(self, graph, request, user_query=None,graph_id=None, summary=None):

--- a/app/services/schema_data.py
+++ b/app/services/schema_data.py
@@ -182,31 +182,88 @@ class SchemaManager:
         return schema_representation
 
     def get_fly_schema_representation(self, prime_service):
+
+        ABSTRACT_NODE_LABELS = {
+            'biological entity', 'position entity', 'coding element',
+            'ontology term', 'ontology class', 'entity',
+            'non coding element', 'genomic variant',
+            'position_entity', 'biological_entity', 'coding_element',
+            'non_coding_element', 'genomic_variant'
+        }
+
+        BIOLINK_SOURCE_MAP = {
+            'biolink:GeneOrGeneProduct': ['gene', 'transcript', 'protein']
+        }
+
+        def normalize(label):
+            """Normalize to underscore format for consistent comparison."""
+            return label.replace(' ', '_').lower() if label else label
+
+        def resolve_labels(value):
+            if value is None:
+                return []
+            items = value if isinstance(value, list) else [value]
+            resolved = []
+            for item in items:
+                if item in BIOLINK_SOURCE_MAP:
+                    resolved.extend(BIOLINK_SOURCE_MAP[item])
+                else:
+                    resolved.append(normalize(item))  # ← normalize here
+            return resolved
+
         fly_schema = {'nodes': {}, 'edges': {}}
 
+        # Step 1: Build edges first — all sources/targets normalized
         for value in prime_service.values():
-            if value.get('is_a') == 'biological entity' or value.get('is_a') == 'position entity':
+            if value.get('represented_as') != 'edge':
                 continue
 
-            if value.get('represented_as') == 'node':
-                if value.get('input_label') == 'ontology term' or value.get('output_label') == 'ontology term':
-                    continue
-                label = value.get('output_label') or value.get('input_label')
-                fly_schema['nodes'][label] = {
-                    'label': label,
-                    'properties': value.get('properties', {}),
-                }
-            elif value.get('represented_as') == 'edge':
-                if value.get('source') == 'ontology term' or value.get('target') == 'ontology term':
-                    continue
-                if value.get('source') is not None and value.get('target') is not None:
-                    label = value.get('output_label') or value.get('input_label')
-                    fly_schema['edges'][label] = {
-                        'source': value.get('source'),
-                        'target': value.get('target'),
+            raw_source = value.get('source')
+            raw_target = value.get('target')
+            if not raw_source or not raw_target:
+                continue
+
+            label = value.get('output_label') or value.get('input_label')
+            sources = resolve_labels(raw_source)
+            targets = resolve_labels(raw_target)
+
+            for s in sources:
+                for t in targets:
+                    if s in ABSTRACT_NODE_LABELS or t in ABSTRACT_NODE_LABELS:
+                        continue
+                    if normalize(s) in {normalize(a) for a in ABSTRACT_NODE_LABELS}:
+                        continue
+                    if normalize(t) in {normalize(a) for a in ABSTRACT_NODE_LABELS}:
+                        continue
+                    edge_key = f"{s}__{label}__{t}"
+                    fly_schema['edges'][edge_key] = {
+                        'source': s,
+                        'target': t,
                         'properties': value.get('properties', {}),
                         'input_label': label,
                     }
+
+        # Step 2: Collect normalized node labels referenced by edges
+        nodes_in_edges = set()
+        for edge in fly_schema['edges'].values():
+            nodes_in_edges.add(normalize(edge['source']))
+            nodes_in_edges.add(normalize(edge['target']))
+
+        # Step 3: Add nodes — normalize their label before comparing
+        for value in prime_service.values():
+            if value.get('represented_as') != 'node':
+                continue
+            label = value.get('output_label') or value.get('input_label')
+            if not label:
+                continue
+            if normalize(label) in {normalize(a) for a in ABSTRACT_NODE_LABELS}:
+                continue
+            if normalize(label) not in nodes_in_edges:  # ← normalized comparison
+                continue
+            fly_schema['nodes'][normalize(label)] = {
+                'label': normalize(label),
+                'properties': value.get('properties', {}),
+            }
 
         return fly_schema
 

--- a/app/services/schema_data.py
+++ b/app/services/schema_data.py
@@ -213,7 +213,7 @@ class SchemaManager:
 
         fly_schema = {'nodes': {}, 'edges': {}}
 
-       # Build edges first — all sources/targets normalized
+        # Build edges first — all sources/targets normalized
         for value in prime_service.values():
             if value.get('represented_as') != 'edge':
                 continue

--- a/app/services/schema_data.py
+++ b/app/services/schema_data.py
@@ -208,12 +208,12 @@ class SchemaManager:
                 if item in BIOLINK_SOURCE_MAP:
                     resolved.extend(BIOLINK_SOURCE_MAP[item])
                 else:
-                    resolved.append(normalize(item))  # ← normalize here
+                    resolved.append(normalize(item))
             return resolved
 
         fly_schema = {'nodes': {}, 'edges': {}}
 
-        # Step 1: Build edges first — all sources/targets normalized
+       # Build edges first — all sources/targets normalized
         for value in prime_service.values():
             if value.get('represented_as') != 'edge':
                 continue
@@ -243,13 +243,13 @@ class SchemaManager:
                         'input_label': label,
                     }
 
-        # Step 2: Collect normalized node labels referenced by edges
+        # Collect normalized node labels referenced by edges
         nodes_in_edges = set()
         for edge in fly_schema['edges'].values():
             nodes_in_edges.add(normalize(edge['source']))
             nodes_in_edges.add(normalize(edge['target']))
 
-        # Step 3: Add nodes — normalize their label before comparing
+        # Add nodes — normalize their label before comparing
         for value in prime_service.values():
             if value.get('represented_as') != 'node':
                 continue

--- a/config/dmel_primer_schema_config.yaml
+++ b/config/dmel_primer_schema_config.yaml
@@ -1,11 +1,13 @@
 Title: BioCypher graph schema configuration file (Biolink-adapted for dmel)
 
+##################             NODES   SECTION             ####################
+
 3d genome structure:
   represented_as: node
   is_a: position entity
   mixins:
-  - biolink:GenomicEntity-test
-  biolink_category: biolink:GenomicEntity-test
+  - biolink:GenomicEntity
+  biolink_category: biolink:GenomicEntity
   input_label: 3d_genome_structure
   inherit_properties: true
   description: A region of the genome that is associated with 3D genome structure
@@ -54,8 +56,8 @@ chromosome chain:
   represented_as: node
   is_a: position entity
   mixins:
-  - biolink:GenomicEntity-test
-  biolink_category: biolink:GenomicEntity-test
+  - biolink:GenomicEntity
+  biolink_category: biolink:GenomicEntity
   inherit_properties: true
   input_label: chromosome_chain
   properties:
@@ -71,9 +73,9 @@ coding element:
   represented_as: node
   is_a: biological entity
   mixins:
-  - biolink:GenomicEntity-test
+  - biolink:GenomicEntity
   - biolink:BiologicalEntity
-  biolink_category: biolink:GenomicEntity-test
+  biolink_category: biolink:GenomicEntity
   input_label: coding_element
   description: A region of a gene that codes for a protein or peptide
   properties:
@@ -370,9 +372,9 @@ position entity:
   represented_as: node
   is_a: biological entity
   mixins:
-  - biolink:GenomicEntity-test
+  - biolink:GenomicEntity
   - biolink:BiologicalEntity
-  biolink_category: biolink:GenomicEntity-test
+  biolink_category: biolink:GenomicEntity
   input_label: position_entity
   description: A biological entity that is defined by its position in the genome
   properties:
@@ -522,6 +524,9 @@ transcript:
   in_subset:
   - model_organism_database
 
+
+##################             EDGES   SECTION             ####################
+
 annotation:
   is_a: related to at concept level
   mixins:
@@ -631,8 +636,7 @@ catalyst protein to reaction or pathway association:
   is_a: annotation
   biolink_predicate: biolink:regulates
   inherit_properties: true
-  description: holds between a protein playing a catalyst role in a reaction and a
-    pathway
+  description: holds between a protein playing a catalyst role in a reaction and a pathway
   represented_as: edge
   input_label: regulates
   source: protein
@@ -849,8 +853,7 @@ exon part_of gene:
   mixins:
   - biolink:SequenceFeatureRelationship
   biolink_predicate: biolink:part_of
-  description: For example, a particular exon is part of a particular transcript or
-    gene
+  description: For example, a particular exon is part of a particular transcript or gene
   represented_as: edge
   input_label: part_of_gene
   output_label: part_of
@@ -1057,8 +1060,7 @@ gene is implicated in disease:
       type: string
 
 gene to disease association:
-  description: An association between a gene and a disease identifier (e.g., OMIM,
-    ORPHA).
+  description: An association between a gene and a disease identifier (e.g., OMIM, ORPHA).
   is_a: association
   mixins:
   - biolink:GeneToDiseaseAssociation
@@ -1155,8 +1157,7 @@ gene to disease model association:
       type: string
 
 gene to gene coexpression association:
-  description: Indicates that two genes are co-expressed, generally under the same
-    conditions.
+  description: Indicates that two genes are co-expressed, generally under the same conditions.
   is_a: expression
   mixins:
   - biolink:GeneToGeneCoexpressionAssociation
@@ -1177,8 +1178,7 @@ gene to gene coexpression association:
       biolink: has_quantitative_value
 
 gene to pathway association:
-  description: An interaction between a gene or gene product and a biological process
-    or pathway.
+  description: An interaction between a gene or gene product and a biological process or pathway.
   is_a: annotation
   mixins:
   - biolink:GeneToPathwayAssociation
@@ -1226,8 +1226,7 @@ gene to phenotype association:
       type: str
 
 gene to reaction association:
-  description: An interaction between a gene or a gene product (gogp) and a reaction
-    (Reactome).
+  description: An interaction between a gene or a gene product (gogp) and a reaction (Reactome).
   is_a: annotation
   biolink_predicate: biolink:participates_in
   inherit_properties: true
@@ -1425,8 +1424,7 @@ negative role protein to reaction or pathway association:
   is_a: annotation
   biolink_predicate: biolink:regulates
   inherit_properties: true
-  description: holds between a protein playing a negative role in a reaction and a
-    pathway
+  description: holds between a protein playing a negative role in a reaction and a pathway
   represented_as: edge
   input_label: negatively_regulates
   source: protein
@@ -1485,8 +1483,7 @@ output role protein to reaction or pathway association:
   is_a: annotation
   biolink_predicate: biolink:produced_by
   inherit_properties: true
-  description: holds between a protein playing an output role in a reaction and a
-    pathway
+  description: holds between a protein playing an output role in a reaction and a pathway
   represented_as: edge
   input_label: produced_by
   source: protein
@@ -1614,8 +1611,7 @@ positive role protein to reaction or pathway association:
   is_a: annotation
   biolink_predicate: biolink:regulates
   inherit_properties: true
-  description: holds between a protein playing a positive role in a reaction and a
-    pathway
+  description: holds between a protein playing a positive role in a reaction and a pathway
   represented_as: edge
   input_label: positively_regulates
   source: protein
@@ -1830,8 +1826,8 @@ regulatory association:
   represented_as: edge
   input_label: regulatory_association
   kgx_properties:
-    subject_category: biolink:GenomicEntity-test
-    object_category: biolink:GenomicEntity-test
+    subject_category: biolink:GenomicEntity
+    object_category: biolink:GenomicEntity
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
   properties:
@@ -1930,8 +1926,7 @@ transcribes to:
   - SIO:010080
 
 transcription factor to gene association:
-  description: A regulatory association between a transcription factor and its target
-    gene
+  description: A regulatory association between a transcription factor and its target gene
   is_a: regulatory association
   biolink_predicate: biolink:regulates
   inherit_properties: true
@@ -1965,8 +1960,7 @@ translates to:
     object_category: biolink:Protein
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
-  description: x (amino acid chain/polypeptide) is the ribosomal translation of y
-    (transcript)
+  description: x (amino acid chain/polypeptide) is the ribosomal translation of y (transcript)
   close_mappings:
   - RO:0002513
   - SIO:010082
@@ -1985,719 +1979,5 @@ uberon subclass of:
   kgx_properties:
     subject_category: biolink:AnatomicalEntity
     object_category: biolink:AnatomicalEntity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-allele:
-  represented_as: node
-  input_label: allele
-  is_a: genomic variant
-  mixins:
-  - biolink:Allele
-  - biolink:SequenceVariant
-  biolink_category: biolink:Allele
-  inherit_properties: true
-  properties:
-    allele_symbol:
-      type: str
-      biolink: symbol
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  description: Different versions of the same variant (in a specific  locus) are called
-    alleles[1, 2]. Most commonly used referring to genes.
-  kgx_properties:
-    category: biolink:Allele
-
-dmel disease model:
-  represented_as: node
-  input_label: dmel_disease_model
-  is_a: biological entity
-  mixins:
-  - biolink:DiseaseModel
-  - biolink:OrganismalEntity
-  biolink_category: biolink:DiseaseModel
-  properties:
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-    gene:
-      type: str
-      biolink: has_gene_or_gene_product
-    do_qualifier:
-      type: str
-      biolink: qualifier
-    do_term_id:
-      type: str
-      biolink: in_disease
-    do_term_name:
-      type: str
-      biolink: name
-    allele:
-      type: str
-      biolink: has_attribute
-    ortholog_hgnc_id:
-      type: str
-      biolink: id
-    ortholog_hgnc_symbol:
-      type: str
-      biolink: symbol
-    evidence_code:
-      type: str
-      biolink: has_evidence
-    interacting_alleles:
-      type: str[]
-      biolink: has_attribute
-    ev_code_interact_alleles:
-      type: str
-      biolink: has_evidence
-    reference_FBrf_id:
-      type: str
-      biolink: publication
-  kgx_properties:
-    category: biolink:DiseaseModel
-
-gene group:
-  represented_as: node
-  input_label: gene_group
-  is_a: biological entity
-  mixins:
-  - biolink:GeneGroup
-  biolink_category: biolink:GeneGroup
-  properties:
-    genes:
-      type: str[]
-      biolink: has_gene_or_gene_product
-    group_symbol:
-      type: str
-      biolink: symbol
-    group_name:
-      type: str
-      biolink: name
-    parent_groups:
-      type: str[]
-      biolink: subclass_of
-    HGNC_family_ID:
-      type: str[]
-      biolink: id
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    category: biolink:GeneGroup
-
-genotype:
-  represented_as: node
-  input_label: genotype
-  is_a: biological entity
-  mixins:
-  - biolink:Genotype
-  biolink_category: biolink:Genotype
-  properties:
-    genotype_ids:
-      type: str
-      biolink: id
-    genotype_symbols:
-      type: str
-      biolink: symbol
-    reference:
-      type: str
-      biolink: publication
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    category: biolink:Genotype
-
-metabolic pathway gene group:
-  represented_as: node
-  input_label: metabolic_pathway_gene_group
-  is_a: biological entity
-  mixins:
-  - biolink:Pathway
-  - biolink:GeneGroup
-  biolink_category: biolink:Pathway
-  properties:
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-    genes:
-      type: str[]
-      biolink: has_gene_or_gene_product
-    group_symbol:
-      type: str
-      biolink: symbol
-    group_name:
-      type: str
-      biolink: name
-    parent_groups:
-      type: str[]
-      biolink: subclass_of
-    HGNC_family_ID:
-      type: str[]
-      biolink: id
-  kgx_properties:
-    category: biolink:Pathway
-
-phenotype_set:
-  represented_as: node
-  input_label: phenotype_set
-  is_a: biological entity
-  mixins:
-  - biolink:PhenotypicFeature
-  biolink_category: biolink:PhenotypicFeature
-  properties:
-    phenotype_ontology_id:
-      type: str
-      biolink: has_attribute
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    category: biolink:PhenotypicFeature
-
-rnaseq library:
-  is_a: entity
-  represented_as: node
-  inherit_properties: false
-  input_label: rnaseq_library
-  mixins:
-  - biolink:DataSet
-  biolink_category: biolink:DataSet
-  description: A library/cluster/sample that is a set of genes and their expression
-    values.
-  properties:
-    name:
-      type: str
-      biolink: name
-    experiment_info:
-      type: str[]
-      biolink: has_attribute
-    tissue_info:
-      type: str[]
-      biolink: has_attribute
-    cell_type_id:
-      type: str
-      biolink: has_cell_type
-    anatomy_entity_id:
-      type: str[]
-      biolink: anatomical_entity
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-    source:
-      type: str
-      biolink: knowledge_source
-    source_url:
-      type: str
-      biolink: source_web_page
-  kgx_properties:
-    category: biolink:DataSet
-
-signaling pathway gene group:
-  represented_as: node
-  input_label: signaling_pathway_gene_group
-  is_a: biological entity
-  mixins:
-  - biolink:Pathway
-  - biolink:GeneGroup
-  biolink_category: biolink:Pathway
-  properties:
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-    genes:
-      type: str[]
-      biolink: has_gene_or_gene_product
-    group_symbol:
-      type: str
-      biolink: symbol
-    group_name:
-      type: str
-      biolink: name
-    parent_groups:
-      type: str[]
-      biolink: subclass_of
-    HGNC_family_ID:
-      type: str[]
-      biolink: id
-  kgx_properties:
-    category: biolink:Pathway
-
-allele to allele genetic interaction:
-  represented_as: edge
-  input_label: allele_to_allele_genetic_interaction
-  is_a: annotation
-  biolink_predicate: biolink:interacts_with
-  source: allele
-  target: allele
-  properties:
-    interaction_description:
-      type: str
-      biolink: description
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Allele
-    object_category: biolink:Allele
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-allele to gene association:
-  is_a: annotation
-  inherit_properties: true
-  represented_as: edge
-  input_label: variant_of
-  biolink_predicate: biolink:variant_of
-  source: allele
-  target: gene
-  properties:
-    taxon_id:
-      type: str
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Allele
-    object_category: biolink:Gene
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-allele to phenotype_set:
-  represented_as: edge
-  input_label: involved_in
-  is_a: annotation
-  biolink_predicate: biolink:involved_in
-  source: allele
-  target: phenotype_set
-  properties:
-    miniref:
-      type: str
-      biolink: publication
-    fb_ref:
-      type: str
-      biolink: publication
-    pmid_ref:
-      type: str
-      biolink: publication
-    pmcid_ref:
-      type: str
-      biolink: publication
-    doi:
-      type: str
-      biolink: publication
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Allele
-    object_category: biolink:PhenotypicFeature
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-expression value:
-  is_a: expression
-  mixins:
-  - biolink:ExpressionQuantitativeTraitLocus
-  biolink_predicate: biolink:has_quantified_expression_level
-  represented_as: edge
-  inherit_properties: false
-  input_label: expression_value
-  source: biolink:GeneOrGeneProduct
-  target: rnaseq library
-  description: A set of values for numeric estimation of single gene/transcript expression
-    as measured by a given methodology (represented by a library).
-  properties:
-    value_and_description:
-      type: list[tuple]
-      biolink: has_quantitative_value
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-    source:
-      type: str
-      biolink: knowledge_source
-    source_url:
-      type: str
-      biolink: source_web_page
-  kgx_properties:
-    subject_category: biolink:GeneOrGeneProduct
-    object_category: biolink:DataSet
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-FBbt subclass of:
-  is_a: subclass of
-  inherit_properties: true
-  represented_as: edge
-  input_label: FBbt_subclass_of
-  output_label: is_a
-  biolink_predicate: biolink:subclass_of
-  source: anatomy
-  target: anatomy
-  kgx_properties:
-    subject_category: biolink:AnatomicalEntity
-    object_category: biolink:AnatomicalEntity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-FBcv subclass of:
-  is_a: subclass of
-  inherit_properties: true
-  represented_as: edge
-  input_label: FBcv_subclass_of
-  output_label: is_a
-  biolink_predicate: biolink:subclass_of
-  source: phenotype
-  target: phenotype
-  kgx_properties:
-    subject_category: biolink:OntologyClass
-    object_category: biolink:OntologyClass
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-FBdv subclass of:
-  is_a: subclass of
-  inherit_properties: true
-  represented_as: edge
-  input_label: FBdv_subclass_of
-  output_label: is_a
-  biolink_predicate: biolink:subclass_of
-  source: developmental stage
-  target: developmental stage
-  kgx_properties:
-    subject_category: biolink:LifeStage
-    object_category: biolink:LifeStage
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-gene genetic association:
-  description: An association between a gene and another gene, i.e., a gene-level
-    genetic interactions in FlyBase. This data is computed from the allele-level genetic
-    interaction data captured by FlyBase curators.
-  is_a: regulatory association
-  inherit_properties: true
-  represented_as: edge
-  input_label: gene_genetic_association
-  biolink_predicate: biolink:genetic_association
-  source: gene
-  target: gene
-  properties:
-    reference:
-      type: str
-      biolink: publication
-    type:
-      type: str
-      biolink: PairwiseGeneToGeneInteraction
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:Gene
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-gene to group association:
-  description: 'An association between a gene and a group of genes: genes are grouped
-    into gene groups based on shared characteristics, such as sequence, biological
-    function, or participation in a biological process'
-  is_a: related to at instance level
-  represented_as: edge
-  input_label: grouped_into
-  biolink_predicate: biolink:member_of
-  source: gene
-  target: gene group
-  properties:
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:GeneGroup
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-gene to metabolic pathway group association:
-  description: 'An association between a gene and a group of genes: genes are grouped
-    into gene groups based on shared characteristics, such as sequence, biological
-    function, or participation in a biological process'
-  is_a: related to at instance level
-  represented_as: edge
-  input_label: metabolic_pathway_grouped_into
-  biolink_predicate: biolink:member_of
-  source: gene
-  target: metabolic pathway gene group
-  properties:
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:Pathway
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-gene to sequence type:
-  is_a: annotation
-  inherit_properties: true
-  represented_as: edge
-  input_label: sequence_classified_as
-  output_label: classified_as
-  biolink_predicate: biolink:classified_as
-  source: gene
-  target: sequence type
-  properties:
-    taxon_id:
-      type: str
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:OntologyClass
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-gene to signaling pathway group association:
-  description: 'An association between a gene and a group of genes: genes are grouped
-    into gene groups based on shared characteristics, such as sequence, biological
-    function, or participation in a biological process'
-  is_a: related to at instance level
-  represented_as: edge
-  input_label: signaling_pathway_grouped_into
-  biolink_predicate: biolink:member_of
-  source: gene
-  target: signaling pathway gene group
-  properties:
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:Pathway
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-modelled to do term:
-  represented_as: edge
-  input_label: modelled_to_do_term
-  is_a: annotation
-  biolink_predicate: biolink:has_phenotype
-  source: gene
-  target: disease
-  properties:
-    disease_model_id:
-      type: str
-      biolink: has_model
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:Disease
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-modelled to human disease:
-  represented_as: edge
-  input_label: modelled_to_human_disease
-  is_a: annotation
-  biolink_predicate: biolink:models
-  source: gene
-  target: dmel disease model
-  properties:
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:DiseaseModel
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-phenotype_set to cellular component:
-  represented_as: edge
-  input_label: inheres_in
-  is_a: annotation
-  biolink_predicate: biolink:inheres_in
-  source: phenotype_set
-  target: cellular component
-  properties:
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:PhenotypicFeature
-    object_category: biolink:CellularComponent
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-phenotype_set to genotype:
-  represented_as: edge
-  input_label: genetically_informed_by
-  is_a: annotation
-  biolink_predicate: biolink:genetically_inferred_from
-  source: phenotype_set
-  target: genotype
-  properties:
-    miniref:
-      type: str
-      biolink: publication
-    fb_ref:
-      type: str
-      biolink: publication
-    pmid_ref:
-      type: str
-      biolink: publication
-    pmcid_ref:
-      type: str
-      biolink: publication
-    doi:
-      type: str
-      biolink: publication
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:PhenotypicFeature
-    object_category: biolink:Genotype
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-phenotype_set to ontology:
-  represented_as: edge
-  input_label: characterized_by
-  is_a: annotation
-  biolink_predicate: biolink:characterized_by
-  source: phenotype_set
-  target: ontology term
-  properties:
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:PhenotypicFeature
-    object_category: biolink:OntologyClass
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-ptp physical interaction type:
-  is_a: expression
-  represented_as: edge
-  input_label: ptp_physical_interaction_type
-  source: ptp physically interacts with
-  target: molecular_interaction
-
-ptp physically interacts with:
-  is_a: expression
-  inherit_properties: true
-  represented_as: edge
-  input_label: ptp_physically_interacts_with
-  biolink_predicate: biolink:physically_interacts_with
-  source: biolink:GeneOrGeneProduct
-  target: protein
-  properties:
-    source_gene:
-      type: str
-      biolink: has_gene_or_gene_product
-    target_gene:
-      type: str
-      biolink: has_gene_or_gene_product
-    detection_method:
-      type: str
-      biolink: has_metric
-    pubmed_ids:
-      type: str[]
-      biolink: publication
-    source_taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-    target_taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-    interaction_type:
-      type: molecular_interaction
-      biolink: has_attribute
-    interaction_comments:
-      type: str
-      biolink: comment
-    source_comments:
-      type: str
-      biolink: comment
-    target_comments:
-      type: str
-      biolink: comment
-  kgx_properties:
-    subject_category: biolink:GeneOrGeneProduct
-    object_category: biolink:Protein
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-ptt physically interacts with:
-  is_a: expression
-  inherit_properties: true
-  represented_as: edge
-  input_label: ptt_physically_interacts_with
-  biolink_predicate: biolink:physically_interacts_with
-  source: biolink:GeneOrGeneProduct
-  target: transcript
-  properties:
-    source_gene:
-      type: str
-      biolink: has_gene_or_gene_product
-    target_gene:
-      type: str
-      biolink: has_gene_or_gene_product
-    detection_method:
-      type: str
-      biolink: has_metric
-    pubmed_ids:
-      type: str[]
-      biolink: publication
-    source_taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-    target_taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-    interaction_type:
-      type: str
-      biolink: has_attribute
-    interaction_comments:
-      type: str
-      biolink: comment
-    source_comments:
-      type: str
-      biolink: comment
-    target_comments:
-      type: str
-      biolink: comment
-  kgx_properties:
-    subject_category: biolink:GeneOrGeneProduct
-    object_category: biolink:Transcript
     knowledge_level: knowledge_assertion
     agent_type: manual_agent

--- a/config/dmel_primer_schema_config.yaml
+++ b/config/dmel_primer_schema_config.yaml
@@ -579,7 +579,7 @@ biological process gene:
   output_label: involved_in
   source: gene
   target: biological process
-  gx_properties:
+  kgx_properties:
     subject_category: biolink:Gene
     object_category: biolink:BiologicalProcess
     knowledge_level: knowledge_assertion

--- a/config/fly_base_schema/dmel_full_schema_config.yaml
+++ b/config/fly_base_schema/dmel_full_schema_config.yaml
@@ -1,5 +1,7 @@
 Title: BioCypher graph schema configuration file (Biolink-adapted for dmel)
 
+##################             NODES   SECTION             ####################
+
 3d genome structure:
   represented_as: node
   is_a: position entity
@@ -25,6 +27,9 @@ anatomy:
   - biolink:AnatomicalEntity
   biolink_category: biolink:AnatomicalEntity
   inherit_properties: true
+  description: >
+    Note: Some CL-prefixed cell type IDs are stored under 'anatomy' in the fly
+    KG because they belong to the UBERON ontology.
   kgx_properties:
     category: biolink:AnatomicalEntity
 
@@ -38,28 +43,6 @@ biological process:
   inherit_properties: true
   kgx_properties:
     category: biolink:BiologicalProcess
-
-cell line:
-  is_a: ontology term
-  represented_as: node
-  input_label: cell_line
-  mixins:
-  - biolink:CellLine
-  biolink_category: biolink:CellLine
-  inherit_properties: true
-  kgx_properties:
-    category: biolink:CellLine
-
-cell type:
-  is_a: ontology term
-  represented_as: node
-  input_label: cell_type
-  mixins:
-  - biolink:Cell
-  biolink_category: biolink:Cell
-  inherit_properties: true
-  kgx_properties:
-    category: biolink:Cell
 
 cellular component:
   is_a: ontology term
@@ -211,7 +194,9 @@ genomic variant:
   biolink_category: biolink:SequenceVariant
   inherit_properties: true
   input_label: genomic_variant
-  description: A genomic variant is a change in one or more sequence of a genome
+  description: >
+    Base variant type used by fly-specific allele node. Human-only subtypes
+    (structural_variant, sequence_variant) have been removed.
   properties:
     source:
       type: str
@@ -492,27 +477,6 @@ reaction:
   kgx_properties:
     category: biolink:MolecularActivity
 
-regulatory region:
-  represented_as: node
-  input_label: regulatory_region
-  is_a: non coding element
-  mixins:
-  - biolink:RegulatoryRegion
-  biolink_category: biolink:RegulatoryRegion
-  inherit_properties: true
-  description: A region of the genome that is involved in gene regulation.
-  kgx_properties:
-    category: biolink:RegulatoryRegion
-  properties:
-    cell:
-      type: str
-    biochemical_activity:
-      type: str
-      biolink: has_biological_sequence
-    biological_context:
-      type: str
-      biolink: has_gene_or_gene_product
-
 sequence type:
   is_a: ontology term
   represented_as: node
@@ -524,31 +488,6 @@ sequence type:
   kgx_properties:
     category: biolink:OntologyClass
 
-sequence variant:
-  represented_as: node
-  input_label: sequence_variant
-  is_a: genomic variant
-  mixins:
-  - biolink:SequenceVariant
-  biolink_category: biolink:SequenceVariant
-  inherit_properties: true
-  kgx_properties:
-    category: biolink:SequenceVariant
-  description: A change in the nucleotide sequence of a genome compared to a reference
-    sequence.
-  properties:
-    rsid:
-      type: str
-      biolink: id
-    ref:
-      type: str
-    alt:
-      type: str
-    raw_cadd_score:
-      type: float
-    phred_score:
-      type: float
-
 small molecule:
   is_a: ontology term
   represented_as: node
@@ -559,51 +498,6 @@ small molecule:
   inherit_properties: true
   kgx_properties:
     category: biolink:ChemicalEntity
-
-structural variant:
-  represented_as: node
-  input_label: structural_variant
-  is_a: genomic variant
-  mixins:
-  - biolink:SequenceVariant
-  biolink_category: biolink:SequenceVariant
-  description: A structural variant is a larger scale genomic alteration that affects
-    the structure of chromosomes, such as deletions, duplications, inversions, and
-    translocations.
-  inherit_properties: true
-  kgx_properties:
-    category: biolink:SequenceVariant
-  properties:
-    variant_accession:
-      type: str
-      biolink: id
-    variant_type:
-      type: str
-    evidence:
-      type: str
-      biolink: has_evidence
-
-tad:
-  represented_as: node
-  input_label: tad
-  is_a: 3d genome structure
-  mixins:
-  - biolink:GenomicEntity
-  biolink_category: biolink:GenomicEntity
-  inherit_properties: true
-  kgx_properties:
-    category: biolink:GenomicEntity
-
-tissue:
-  is_a: ontology term
-  mixins:
-  - biolink:AnatomicalEntity
-  biolink_category: biolink:AnatomicalEntity
-  represented_as: node
-  input_label: tissue
-  inherit_properties: true
-  kgx_properties:
-    category: biolink:AnatomicalEntity
 
 transcript:
   represented_as: node
@@ -635,1811 +529,6 @@ transcript:
   in_subset:
   - model_organism_database
 
-transcription binding site:
-  represented_as: node
-  input_label: tfbs
-  is_a: position entity
-  mixins:
-  - biolink:RegulatoryRegion
-  biolink_category: biolink:RegulatoryRegion
-  inherit_properties: true
-  description: A region of DNA where a transcription factor binds to regulate gene
-    expression
-  kgx_properties:
-    category: biolink:RegulatoryRegion
-
-annotation:
-  is_a: related to at concept level
-  mixins:
-  - biolink:Association
-  biolink_predicate: biolink:related_to
-  represented_as: edge
-  input_label: annotation
-  kgx_properties:
-    subject_category: biolink:OntologyClass
-    object_category: biolink:NamedThing
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  description: An association between a gene/ontology term and another entity
-  properties:
-    source:
-      type: str
-      biolink: knowledge_source
-    source_url:
-      type: str
-      biolink: source_web_page
-
-association:
-  description: A typed association between two entities that represents some form
-    of  relationship or connection in a biomedical context.
-  abstract: true
-  represented_as: edge
-  properties:
-    source:
-      type: str
-      biolink: knowledge_source
-    source_url:
-      type: str
-      biolink: source_web_page
-    knowledge_level:
-      type: str
-      const: knowledge_assertion
-    agent_type:
-      type: str
-      const: manual_agent
-  kgx_properties:
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-biological process gene:
-  is_a: go gene
-  biolink_predicate: biolink:involved_in
-  inherit_properties: true
-  represented_as: edge
-  input_label: biological_process_gene
-  output_label: involved_in
-  source: gene
-  target: biological process
-  gx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:BiologicalProcess
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-biological process gene product:
-  is_a: go gene product
-  biolink_predicate: biolink:involved_in
-  inherit_properties: true
-  represented_as: edge
-  input_label: biological_process_gene_product
-  output_label: involved_in
-  source: protein
-  target: biological process
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:BiologicalProcess
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-biological process rna:
-  is_a: annotation
-  mixins:
-  - biolink:annotation
-  biolink_predicate: biolink:participates_in
-  inherit_properties: true
-  represented_as: edge
-  input_label: biological_process_rna
-  output_label: participates_in
-  source: non coding rna
-  target: biological process
-  kgx_properties:
-    subject_category: biolink:RNAProduct
-    object_category: biolink:BiologicalProcess
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-biological process subclass:
-  is_a: subclass of
-  biolink_predicate: biolink:subclass_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: biological_process_subclass_of
-  output_label: is_a
-  source: biological process
-  target: biological process
-  kgx_properties:
-    subject_category: biolink:BiologicalProcess
-    object_category: biolink:BiologicalProcess
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-bto subclass of:
-  is_a: subclass of
-  mixins:
-  - biolink:AnatomicalEntityToAnatomicalEntityAssociation
-  biolink_predicate: biolink:subclass_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: bto_subclass_of
-  output_label: is_a
-  source: tissue
-  target: tissue
-  kgx_properties:
-    subject_category: biolink:AnatomicalEntity
-    object_category: biolink:AnatomicalEntity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-catalyst protein to reaction or pathway association:
-  is_a: annotation
-  biolink_predicate: biolink:regulates
-  inherit_properties: true
-  description: holds between a protein playing an input role in a reaction and a pathway
-  represented_as: edge
-  input_label: regulates
-  source: protein
-  target: biolink:BiologicalProcessOrActivity
-  properties:
-    relation_ontology_term: str
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:MolecularActivity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-cell line is a cell type:
-  is_a: subclass of
-  biolink_predicate: biolink:subclass_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: cell_line_is_a_cell_type
-  output_label: is_a
-  kgx_properties:
-    subject_category: biolink:CellLine
-    object_category: biolink:Cell
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  description: Cross-ontology relation linking a Cell Line Ontology (CLO) term to
-    a Cell Ontology (CL) term.
-  source: cell line
-  target: cell type
-
-cell type part of tissue:
-  is_a: part of
-  biolink_predicate: biolink:part_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: cell_type_part_of_tissue
-  output_label: part_of
-  kgx_properties:
-    subject_category: biolink:Cell
-    object_category: biolink:AnatomicalEntity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  description: Cross-ontology relation linking a CL cell type to a BTO tissue term.
-  source: cell type
-  target: tissue
-
-cellular component gene:
-  is_a: go gene
-  biolink_predicate: biolink:CellularComponent
-  inherit_properties: true
-  represented_as: edge
-  input_label: cellular_component_gene
-  source: gene
-  target: cellular component
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:CellularComponent
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-cellular component gene located in:
-  is_a: cellular component gene
-  biolink_predicate: biolink:located_in
-  inherit_properties: true
-  represented_as: edge
-  input_label: cellular_component_gene_located_in
-  output_label: located_in
-  source: gene
-  target: cellular component
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:CellularComponent
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-cellular component gene part of:
-  is_a: cellular component gene
-  biolink_predicate: biolink:part_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: cellular_component_gene_part_of
-  output_label: part_of
-  source: gene
-  target: cellular component
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:CellularComponent
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-cellular component gene product:
-  is_a: go gene product
-  biolink_predicate: biolink:located_in
-  inherit_properties: true
-  represented_as: edge
-  input_label: cellular_component_gene_product
-  source: protein
-  target: cellular component
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:CellularComponent
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-cellular component gene product located in:
-  is_a: cellular component gene product
-  biolink_predicate: biolink:located_in
-  inherit_properties: true
-  represented_as: edge
-  input_label: cellular_component_gene_product_located_in
-  output_label: located_in
-  source: protein
-  target: cellular component
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:CellularComponent
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-cellular component gene product part of:
-  is_a: cellular component gene product
-  biolink_predicate: biolink:part_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: cellular_component_gene_product_part_of
-  output_label: part_of
-  source: protein
-  target: cellular component
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:CellularComponent
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-cellular component rna:
-  is_a: annotation
-  mixins:
-  - biolink:annotation
-  biolink_predicate: biolink:located_in
-  inherit_properties: true
-  represented_as: edge
-  input_label: cellular_component_rna
-  output_label: located_in
-  source: non coding rna
-  target: cellular component
-  kgx_properties:
-    subject_category: biolink:RNAProduct
-    object_category: biolink:CellularComponent
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-cellular component subclass:
-  is_a: subclass of
-  biolink_predicate: biolink:subclass_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: cellular_component_subclass_of
-  output_label: is_a
-  source: cellular component
-  target: cellular component
-  kgx_properties:
-    subject_category: biolink:CellularComponent
-    object_category: biolink:CellularComponent
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-chebi subclass of:
-  is_a: subclass of
-  inherit_properties: true
-  represented_as: edge
-  input_label: chebi_subclass_of
-  output_label: is_a
-  biolink_predicate: biolink:subclass_of
-  source: small molecule
-  target: small molecule
-  kgx_properties:
-    subject_category: biolink:ChemicalEntity
-    object_category: biolink:ChemicalEntity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-chemical_substance part_of chemical_substance:
-  is_a: association
-  biolink_predicate: biolink:part_of
-  represented_as: edge
-  input_label: chemical_substance_part_of_chemical_substance
-  output_label: part_of
-  source: small molecule
-  target: small molecule
-  properties:
-    evidence:
-      type: str[]
-      biolink: has_evidence
-  kgx_properties:
-    subject_category: biolink:ChemicalEntity
-    object_category: biolink:ChemicalEntity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-child pathway of:
-  is_a: annotation
-  biolink_predicate: biolink:part_of
-  inherit_properties: true
-  description: holds between two pathways where the domain class is a child pathway
-    of the range class
-  represented_as: edge
-  input_label: child_pathway_of
-  source: pathway
-  target: pathway
-  kgx_properties:
-    subject_category: biolink:Pathway
-    object_category: biolink:Pathway
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-cl capable of:
-  is_a: annotation
-  biolink_predicate: biolink:capable_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: cl_capable_of
-  output_label: capable_of
-  kgx_properties:
-    subject_category: biolink:Cell
-    object_category: biolink:BiologicalProcess
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  description: Represents the capability of a cell type (CL term) to carry out or
-    be involved in a specific biological process.
-  source: cell type
-  target: biological process
-
-cl part of:
-  is_a: part of
-  biolink_predicate: biolink:part_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: cl_part_of
-  output_label: part_of
-  kgx_properties:
-    subject_category: biolink:Cell
-    object_category: biolink:AnatomicalEntity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  description: Represents a part-whole relationship between a CL term and an UBERON
-    term.
-  source: cell type
-  target: anatomy
-
-cl subclass of:
-  is_a: subclass of
-  biolink_predicate: biolink:subclass_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: cl_subclass_of
-  output_label: is_a
-  source: cell type
-  target: cell type
-  kgx_properties:
-    subject_category: biolink:Cell
-    object_category: biolink:Cell
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-clo subclass of:
-  is_a: subclass of
-  biolink_predicate: biolink:subclass_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: clo_subclass_of
-  output_label: is_a
-  source: cell line
-  target: cell line
-  kgx_properties:
-    subject_category: biolink:CellLine
-    object_category: biolink:CellLine
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-do subclass of:
-  is_a: subclass of
-  inherit_properties: true
-  represented_as: edge
-  input_label: do_subclass_of
-  output_label: is_a
-  biolink_predicate: biolink:subclass_of
-  source: disease
-  target: disease
-  kgx_properties:
-    subject_category: biolink:Disease
-    object_category: biolink:Disease
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-efo subclass of:
-  is_a: subclass of
-  biolink_predicate: biolink:subclass_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: efo_subclass_of
-  output_label: is_a
-  source: experimental factor
-  target: experimental factor
-  kgx_properties:
-    subject_category: biolink:OntologyClass
-    object_category: biolink:OntologyClass
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-enhancer to gene association:
-  description: An association between an enhancer and a gene
-  is_a: regulatory association
-  mixins:
-  - biolink:association
-  biolink_predicate: biolink:associated_with
-  inherit_properties: true
-  represented_as: edge
-  input_label: enhancer_gene
-  output_label: associated_with
-  source: enhancer
-  target: gene
-  kgx_properties:
-    subject_category: biolink:RegulatoryRegion
-    object_category: biolink:Gene
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    score:
-      type: float
-      biolink: has_quantitative_value
-    biological_context:
-      type: str
-      biolink: has_biological_sequence
-
-exon part_of gene:
-  is_a: related to at instance
-  mixins:
-  - biolink:SequenceFeatureRelationship
-  biolink_predicate: biolink:part_of
-  description: 'Description: For example, a particular exon is part of a particular
-    transcript or gene    '
-  represented_as: edge
-  input_label: part_of_gene
-  output_label: part_of
-  source: exon
-  target: gene
-  properties:
-    source:
-      type: str
-      biolink: provided_by
-    source_url:
-      type: str
-      biolink: source_web_page
-    taxon_id:
-      description: Taxon ID for the organism (e.g., 7227 for fruit fly, 9606 for human)
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Transcript
-    object_category: biolink:Exon
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-exon part_of transcript:
-  is_a: related to at instance
-  mixins:
-  - biolink:ExonToTranscriptRelationship
-  biolink_predicate: biolink:has_part
-  description: An association between an exon and its gene
-  represented_as: edge
-  input_label: part_of_transcript
-  output_label: part_of
-  source: exon
-  target: transcript
-  properties:
-    source:
-      type: str
-      biolink: provided_by
-    source_url:
-      type: str
-      biolink: source_web_page
-    taxon_id:
-      description: Taxon ID for the organism (e.g., 7227 for fruit fly, 9606 for human)
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Transcript
-    object_category: biolink:Exon
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-expressed in:
-  description: holds between a gene and an ontology term in which it is expressed
-  is_a: expression
-  mixins:
-  - biolink:GeneToExpressionSiteAssociation
-  biolink_predicate: biolink:expressed_in
-  inherit_properties: true
-  represented_as: edge
-  input_label: expressed_in
-  source: gene
-  target: ontology term
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:OntologyClass
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    score:
-      type: float
-      biolink: has_quantitative_value
-    p_value:
-      type: float
-      biolink: has_quantitative_value
-
-expression:
-  is_a: association
-  biolink_predicate: biolink:related_to
-  represented_as: edge
-  input_label: expression
-  description: An association between a gene and its expression
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:GeneOrGeneProduct
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    source:
-      type: str
-      biolink: knowledge_source
-    source_url:
-      type: str
-      biolink: source_web_page
-
-feature overlaps structural_variant:
-  is_a: association
-  biolink_predicate: biolink:overlaps
-  represented_as: edge
-  input_label: feature_overlaps_structural_variant
-  output_label: overlaps
-  source: biological entity
-  target: structural variant
-  kgx_properties:
-    subject_category: biolink:GenomicEntity
-    object_category: biolink:SequenceVariant
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-gene biomarker via orthology disease:
-  description: A gene is a biomarker for a disease via orthology relationship. From
-    Alliance for Genome Resources.
-  is_a: association
-  mixins:
-  - biolink:Association
-  biolink_predicate: biolink:biomarker_for
-  inherit_properties: true
-  represented_as: edge
-  input_label: biomarker_via_orthology
-  source: gene
-  target: disease
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:Disease
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    taxon_id:
-      type: integer
-    evidence_code:
-      type: string
-    evidence_code_name:
-      type: string
-    reference:
-      type: string
-    date:
-      type: string
-    data_source:
-      type: string
-    with_ortholog:
-      type: string
-    inferred_from_id:
-      type: string
-    inferred_from_symbol:
-      type: string
-
-gene implicated via orthology disease:
-  description: A gene is implicated in a disease via orthology relationship. From
-    Alliance for Genome Resources.
-  is_a: association
-  mixins:
-  - biolink:Association
-  biolink_predicate: biolink:implicated_in
-  inherit_properties: true
-  represented_as: edge
-  input_label: implicated_via_orthology
-  source: gene
-  target: disease
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:Disease
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    taxon_id:
-      type: integer
-    evidence_code:
-      type: string
-    evidence_code_name:
-      type: string
-    reference:
-      type: string
-    date:
-      type: string
-    data_source:
-      type: string
-    with_ortholog:
-      type: string
-    inferred_from_id:
-      type: string
-    inferred_from_symbol:
-      type: string
-
-gene in tad region:
-  is_a: association
-  biolink_predicate: biolink:located_in
-  description: holds between a tad and a gene that is in the tad region
-  represented_as: edge
-  input_label: in_tad_region
-  source: gene
-  target: tad
-  properties:
-    taxon_id:
-      description: Taxon ID for the organism (e.g., 7227 for fruit fly, 9606 for human)
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:GenomicEntity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-gene is implicated in disease:
-  description: A gene is implicated in a disease. From Alliance for Genome Resources.
-  is_a: association
-  mixins:
-  - biolink:Association
-  biolink_predicate: biolink:implicated_in
-  inherit_properties: true
-  represented_as: edge
-  input_label: is_implicated_in
-  source: gene
-  target: disease
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:Disease
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    taxon_id:
-      type: integer
-    evidence_code:
-      type: string
-    evidence_code_name:
-      type: string
-    reference:
-      type: string
-    date:
-      type: string
-    data_source:
-      type: string
-    with_ortholog:
-      type: string
-    inferred_from_id:
-      type: string
-    inferred_from_symbol:
-      type: string
-
-gene overlaps structural_variant:
-  is_a: association
-  biolink_predicate: biolink:overlaps
-  represented_as: edge
-  input_label: gene_overlaps_structural_variant
-  output_label: overlaps
-  source: gene
-  target: structural variant
-
-gene to disease association:
-  description: An association between a gene and a disease identifier (e.g., OMIM,
-    ORPHA).
-  is_a: association
-  mixins:
-  - biolink:GeneToDiseaseAssociation
-  biolink_predicate: biolink:associated_with
-  inherit_properties: true
-  represented_as: edge
-  input_label: gene_disease
-  output_label: associated_with
-  source: gene
-  target: disease
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:Disease
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    gene_symbol:
-      type: str
-    association_type:
-      type: str
-    source_ref:
-      type: str
-
-gene to disease marker association:
-  description: Gene is a marker for a disease
-  is_a: association
-  mixins:
-  - biolink:Association
-  biolink_predicate: biolink:model_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: is_marker_for
-  source: gene
-  target: disease
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:Disease
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    taxon_id:
-      type: integer
-    evidence_code:
-      type: string
-    evidence_code_name:
-      type: string
-    reference:
-      type: string
-    date:
-      type: string
-    data_source:
-      type: string
-    with_ortholog:
-      type: string
-    inferred_from_id:
-      type: string
-    inferred_from_symbol:
-      type: string
-
-gene to disease model association:
-  description: Gene is a model for disease
-  is_a: association
-  mixins:
-  - biolink:Association
-  biolink_predicate: biolink:model_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: is_model_of
-  source: gene
-  target: disease
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:Disease
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    taxon_id:
-      type: integer
-    evidence_code:
-      type: string
-    evidence_code_name:
-      type: string
-    reference:
-      type: string
-    date:
-      type: string
-    data_source:
-      type: string
-    with_ortholog:
-      type: string
-    inferred_from_id:
-      type: string
-    inferred_from_symbol:
-      type: string
-
-gene to gene coexpression association:
-  description: Indicates that two genes are co-expressed, generally under the same
-    conditions.
-  is_a: expression
-  mixins:
-  - biolink:GeneToGeneCoexpressionAssociation
-  biolink_predicate: biolink:coexpressed_with
-  inherit_properties: true
-  represented_as: edge
-  input_label: coexpressed_with
-  source: gene
-  target: gene
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:Gene
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    score:
-      type: float
-      biolink: has_quantitative_value
-
-gene to pathway association:
-  description: An interaction between a gene or gene product and a biological process
-    or pathway.
-  is_a: annotation
-  mixins:
-  - biolink:GeneToPathwayAssociation
-  biolink_predicate: biolink:participates_in
-  inherit_properties: true
-  represented_as: edge
-  input_label: genes_pathways
-  output_label: participates_in
-  source:
-  - gene
-  - transcript
-  - protein
-  target: pathway
-  kgx_properties:
-    subject_category: biolink:GeneOrGeneProduct
-    object_category: biolink:Pathway
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-gene to phenotype association:
-  description: An association between a gene and a phenotype (HPO term).
-  is_a: association
-  mixins:
-  - biolink:GeneToPhenotypicFeatureAssociation
-  biolink_predicate: biolink:has_phenotype
-  inherit_properties: true
-  represented_as: edge
-  input_label: gene_phenotype
-  output_label: involved_in
-  source: gene
-  target: phenotype
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:PhenotypicFeature
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    gene_symbol:
-      type: str
-    phenotype_name:
-      type: str
-    frequency:
-      type: str
-    disease_id:
-      type: str
-
-gene to reaction association:
-  description: An interaction between a gene or a gene product (gogp) and a reaction
-    (Reactome).
-  is_a: annotation
-  biolink_predicate: biolink:participates_in
-  inherit_properties: true
-  represented_as: edge
-  input_label: gene_or_gene_product_reaction
-  output_label: involved_in
-  source: biolink:GeneOrGeneProduct
-  target: reaction
-  kgx_properties:
-    subject_category: biolink:GeneOrGeneProduct
-    object_category: biolink:MolecularActivity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-gene to transcription binding site association:
-  represented_as: edge
-  is_a: related at instance level
-  biolink_predicate: biolink:interacts_with
-  input_label: gene_tfbs
-  output_label: binds_to
-  description: An association between a transcription factor and its binding site
-  source: gene
-  target: tfbs
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:RegulatoryRegion
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    score:
-      type: float
-      biolink: has_quantitative_value
-    source:
-      type: str
-      biolink: primary_knowledge_source
-    source_url:
-      type: str
-      biolink: source_web_page
-
-go gene:
-  is_a: annotation
-  biolink_predicate: biolink:has_gene_product
-  inherit_properties: true
-  represented_as: edge
-  input_label: go_gene
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:OntologyClass
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    db_reference:
-      type: str[]
-      biolink: publication
-    evidence:
-      type: str
-      biolink: has_evidence
-    taxon_id:
-      type: str
-      biolink: taxon
-
-go gene product:
-  is_a: annotation
-  mixins:
-  - biolink:GeneToGoTermAssociation
-  biolink_predicate: biolink:has_gene_product
-  inherit_properties: true
-  represented_as: edge
-  input_label: go_gene_product
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:OntologyClass
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    db_reference:
-      type: str[]
-      biolink: publication
-    evidence:
-      type: str
-      biolink: has_evidence
-    taxon_id:
-      type: str
-      biolink: taxon
-
-has part:
-  is_a: annotation
-  biolink_predicate: biolink:has_part
-  inherit_properties: true
-  represented_as: edge
-  input_label: has_part
-  source: ontology term
-  target: ontology term
-  kgx_properties:
-    subject_category: biolink:OntologyClass
-    object_category: biolink:OntologyClass
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-has xref:
-  is_a: annotation
-  mixins:
-  - biolink:Association
-  biolink_predicate: biolink:xref
-  represented_as: edge
-  input_label: has_xref
-  output_label: has_xref
-  source: biological entity
-  target: biological entity
-  kgx_properties:
-    subject_category: biolink:NamedThing
-    object_category: biolink:NamedThing
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    xref_db:
-      type: str
-      biolink: knowledge_source
-    evidence:
-      type: str[]
-      biolink: has_evidence
-
-input role protein to reaction or pathway association:
-  is_a: annotation
-  biolink_predicate: biolink:is_input_of
-  inherit_properties: true
-  description: holds between a protein playing an input role in a reaction and a pathway
-  represented_as: edge
-  input_label: enables
-  source: protein
-  target: biolink:BiologicalProcessOrActivity
-  properties:
-    relation_ontology_term: str
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:MolecularActivity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-mi subclass of:
-  is_a: subclass of
-  inherit_properties: true
-  represented_as: edge
-  input_label: mi_subclass_of
-  output_label: is_a
-  biolink_predicate: biolink:subclass_of
-  source: molecular interaction
-  target: molecular interaction
-  kgx_properties:
-    subject_category: biolink:OntologyClass
-    object_category: biolink:OntologyClass
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-molecular function gene:
-  is_a: go gene
-  biolink_predicate: biolink:enables
-  inherit_properties: true
-  represented_as: edge
-  input_label: molecular_function_gene
-  output_label: enables
-  source: gene
-  target: molecular function
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:MolecularActivity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-molecular function gene product:
-  is_a: go gene product
-  biolink_predicate: biolink:enables
-  inherit_properties: true
-  represented_as: edge
-  input_label: molecular_function_gene_product
-  output_label: enables
-  source: protein
-  target: molecular function
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:MolecularActivity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-molecular function rna:
-  is_a: annotation
-  mixins:
-  - biolink:annotation
-  biolink_predicate: biolink:enables
-  inherit_properties: true
-  represented_as: edge
-  input_label: molecular_function_rna
-  output_label: enables
-  source: non coding rna
-  target: molecular function
-  kgx_properties:
-    subject_category: biolink:RNAProduct
-    object_category: biolink:MolecularActivity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-molecular function subclass:
-  is_a: subclass of
-  mixins:
-  - biolink:MolecularActivityToMolecularActivityAssociation
-  biolink_predicate: biolink:subclass_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: molecular_function_subclass_of
-  output_label: is_a
-  source: molecular function
-  target: molecular function
-  kgx_properties:
-    subject_category: biolink:MolecularActivity
-    object_category: biolink:MolecularActivity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-negative role protein to reaction or pathway association:
-  is_a: annotation
-  biolink_predicate: biolink:regulates
-  inherit_properties: true
-  description: holds between a protein playing an input role in a reaction and a pathway
-  represented_as: edge
-  input_label: negatively_regulates
-  source: protein
-  target: biolink:BiologicalProcessOrActivity
-  properties:
-    relation_ontology_term: str
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:MolecularActivity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-non_coding_rna overlaps structural_variant:
-  is_a: association
-  biolink_predicate: biolink:overlaps
-  represented_as: edge
-  input_label: non_coding_rna_overlaps_structural_variant
-  output_label: overlaps
-  source: non_coding_rna
-  target: structural variant
-
-orthology association:
-  description: Non-directional association between two genes indicating that there
-    is an orthology relation among them. It  is a historical homology that involves
-    genes that diverged after a speciation event (purl.obolibrary.org/obo/RO_HOM0000017)
-  is_a: related to at instance level
-  represented_as: edge
-  input_label: orthologs_genes
-  biolink_predicate: biolink:ortholog_of
-  source: gene
-  target: gene
-  properties:
-    DIOPT_score:
-      type: int
-      biolink: has_quantitative_value
-    hsa_hgnc_id:
-      type: str
-      biolink: id
-    hsa_omim_id:
-      type: str
-      biolink: id
-    hsa_omim_phenotype_ids:
-      type: str
-      biolink: has_phenotype
-    hsa_omim_phenotype_ids_names:
-      type: str
-      biolink: has_phenotype_label
-    source_organism:
-      type: str
-      biolink: in_taxon
-    target_organism:
-      type: str
-      biolink: in_taxon
-    taxon_id:
-      description: Taxon ID for the organism (e.g., 7227 for fruit fly, 9606 for human)
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:Gene
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-output role protein to reaction or pathway association:
-  is_a: annotation
-  biolink_predicate: biolink:produced_by
-  inherit_properties: true
-  description: holds between a protein playing an input role in a reaction and a pathway
-  represented_as: edge
-  input_label: produced_by
-  source: protein
-  target: biolink:BiologicalProcessOrActivity
-  properties:
-    relation_ontology_term: str
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:MolecularActivity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-paralogy association:
-  description: Non-directional association between two genes indicating that there
-    is an paralogy relation among them. It is a historical homology that involves
-    genes that diverged after a duplication event (purl.obolibrary.org/obo/RO_HOM0000011)
-  is_a: related to at instance level
-  represented_as: edge
-  input_label: paralogs_genes
-  biolink_predicate: biolink:paralog_of
-  source: gene
-  target: gene
-  properties:
-    source_symbol:
-      type: str
-      biolink: symbol
-    target_symbol:
-      type: str
-      biolink: symbol
-    DIOPT_score:
-      type: int
-      biolink: has_quantitative_value
-    taxon_id:
-      type: int
-      biolink: taxon
-      range: biolink:OrganismTaxon
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:Gene
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-parent pathway of:
-  is_a: annotation
-  biolink_predicate: biolink:has_part
-  inherit_properties: true
-  description: holds between two pathways where the domain class is a parent pathway
-    of the range class
-  represented_as: edge
-  input_label: parent_pathway_of
-  source: pathway
-  target: pathway
-  kgx_properties:
-    subject_category: biolink:Pathway
-    object_category: biolink:Pathway
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-part of:
-  is_a: annotation
-  biolink_predicate: biolink:part_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: part_of
-  source: ontology term
-  target: ontology term
-  kgx_properties:
-    subject_category: biolink:OntologyClass
-    object_category: biolink:OntologyClass
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-pathway_to_biological_process:
-  is_a: association
-  biolink_predicate: biolink:participates_in
-  source: pathway
-  target: biological process
-  represented_as: edge
-  input_label: pathway_to_biological_process
-  output_label: equivalent_to
-  description: An association between a pathway and a biological process, indicating
-    that the pathway is involved in the process.
-  properties:
-    source:
-      type: str
-      biolink: knowledge_source
-    source_url:
-      type: str
-      biolink: source_web_page
-  kgx_properties:
-    subject_category: biolink:Pathway
-    object_category: biolink:BiologicalProcess
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-pathway_to_cellular_component:
-  is_a: association
-  source: pathway
-  target: cellular component
-  biolink_predicate: biolink:related_to
-  represented_as: edge
-  input_label: pathway_to_cellular_component
-  description: An association between a pathway and a cellular component, indicating
-    that the pathway is associated with the component.
-  properties: {}
-  kgx_properties:
-    subject_category: biolink:Pathway
-    object_category: biolink:CellularComponent
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-pathway_to_molecular_function:
-  is_a: association
-  source: pathway
-  target: molecular function
-  biolink_predicate: biolink:related_to
-  represented_as: edge
-  input_label: pathway_to_molecular_function
-  description: An association between a pathway and a molecular function, indicating
-    that the pathway is involved in the function.
-  properties: {}
-  kgx_properties:
-    subject_category: biolink:Pathway
-    object_category: biolink:MolecularActivity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-positive role protein to reaction or pathway association:
-  is_a: annotation
-  biolink_predicate: biolink:regulates
-  inherit_properties: true
-  description: holds between a protein playing an input role in a reaction and a pathway
-  represented_as: edge
-  input_label: positively_regulates
-  source: protein
-  target: biolink:BiologicalProcessOrActivity
-  properties:
-    relation_ontology_term: str
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:MolecularActivity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-post translational interaction:
-  is_a: expression
-  biolink_predicate: biolink:interacts_with
-  inherit_properties: true
-  represented_as: edge
-  input_label: interacts_with
-  source: protein
-  target: protein
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:Protein
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    score:
-      type: float
-      biolink: has_quantitative_value
-    interaction_type:
-      type: str
-    reactome_pathway:
-      type: str
-
-promoter overlaps structural_variant:
-  is_a: association
-  biolink_predicate: biolink:overlaps
-  represented_as: edge
-  input_label: promoter_overlaps_structural_variant
-  output_label: overlaps
-  source: promoter
-  target: structural variant
-
-promoter to gene association:
-  description: An association between a promoter and a gene
-  is_a: regulatory association
-  biolink_predicate: biolink:associated_with
-  inherit_properties: true
-  represented_as: edge
-  input_label: promoter_gene
-  output_label: associated_with
-  source: promoter
-  target: gene
-  kgx_properties:
-    subject_category: biolink:RegulatoryRegion
-    object_category: biolink:Gene
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    score:
-      type: float
-      biolink: has_quantitative_value
-    biological_context:
-      type: str
-      biolink: has_biological_sequence
-
-protein has_xref binding_site_ligand:
-  is_a: has xref
-  biolink_predicate: biolink:xref
-  inherit_properties: true
-  represented_as: edge
-  input_label: protein_has_xref_binding_site_ligand
-  output_label: has_xref
-  source: protein
-  target: small molecule
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:ChemicalEntity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-protein has_xref biological_process:
-  is_a: has xref
-  biolink_predicate: biolink:xref
-  inherit_properties: true
-  represented_as: edge
-  input_label: protein_has_xref_biological_process
-  output_label: has_xref
-  source: protein
-  target: biological process
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:BiologicalProcess
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-protein has_xref catalytic_activity:
-  is_a: has xref
-  biolink_predicate: biolink:xref
-  inherit_properties: true
-  represented_as: edge
-  input_label: protein_has_xref_catalytic_activity
-  output_label: has_xref
-  source: protein
-  target: small molecule
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:ChemicalEntity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-protein has_xref cellular_component:
-  is_a: has xref
-  biolink_predicate: biolink:xref
-  inherit_properties: true
-  represented_as: edge
-  input_label: protein_has_xref_cellular_component
-  output_label: has_xref
-  source: protein
-  target: cellular component
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:CellularComponent
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-protein has_xref cofactor:
-  is_a: has xref
-  biolink_predicate: biolink:xref
-  inherit_properties: true
-  represented_as: edge
-  input_label: protein_has_xref_cofactor
-  output_label: has_xref
-  source: protein
-  target: small molecule
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:ChemicalEntity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-protein has_xref gene:
-  is_a: has xref
-  biolink_predicate: biolink:xref
-  inherit_properties: true
-  represented_as: edge
-  input_label: protein_has_xref_gene
-  output_label: has_xref
-  source: protein
-  target: gene
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:Gene
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-protein has_xref molecular_function:
-  is_a: has xref
-  biolink_predicate: biolink:xref
-  inherit_properties: true
-  represented_as: edge
-  input_label: protein_has_xref_molecular_function
-  output_label: has_xref
-  source: protein
-  target: molecular function
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:MolecularActivity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-protein has_xref protein:
-  is_a: has xref
-  biolink_predicate: biolink:xref
-  inherit_properties: true
-  represented_as: edge
-  input_label: protein_has_xref_protein
-  output_label: has_xref
-  source: protein
-  target: protein
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:Protein
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-protein has_xref transcript:
-  is_a: has xref
-  biolink_predicate: biolink:xref
-  inherit_properties: true
-  represented_as: edge
-  input_label: protein_has_xref_transcript
-  output_label: has_xref
-  source: protein
-  target: transcript
-  kgx_properties:
-    subject_category: biolink:Protein
-    object_category: biolink:Transcript
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-reaction to pathway association:
-  is_a: annotation
-  biolink_predicate: biolink:part_of
-  inherit_properties: true
-  description: holds between a reaction and a pathway
-  represented_as: edge
-  input_label: reaction_to_pathway
-  output_label: part_of
-  source: reaction
-  target: pathway
-  kgx_properties:
-    subject_category: biolink:MolecularActivity
-    object_category: biolink:Pathway
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-regulatory association:
-  is_a: association
-  biolink_predicate: biolink:related_to
-  represented_as: edge
-  input_label: regulatory_association
-  kgx_properties:
-    subject_category: biolink:GenomicEntity
-    object_category: biolink:GenomicEntity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    source:
-      type: str
-      biolink: knowledge_source
-    source_url:
-      type: str
-      biolink: source_web_page
-
-regulatory region to gene association:
-  description: An association between a regulatory region and a gene it regulates
-  is_a: regulatory association
-  mixins:
-  - biolink:Association
-  biolink_predicate: biolink:regulates
-  inherit_properties: true
-  represented_as: edge
-  input_label: regulatory_region_gene
-  output_label: regulates
-  source: regulatory_region
-  target: gene
-  kgx_properties:
-    subject_category: biolink:RegulatoryRegion
-    object_category: biolink:Gene
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    score: float
-    biological_context: str
-
-small molecule to pathway association:
-  description: An interaction between a small molecule (ChEBI) and a pathway (Reactome).
-  is_a: annotation
-  mixins:
-  - biolink:MolecularActivityToPathwayAssociation
-  biolink_predicate: biolink:participates_in
-  inherit_properties: true
-  represented_as: edge
-  input_label: small_molecule_to_pathway
-  output_label: participates_in
-  source: small molecule
-  target: pathway
-  kgx_properties:
-    subject_category: biolink:SmallMolecule
-    object_category: biolink:Pathway
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-small molecule to reaction association:
-  description: An interaction between a small molecule (ChEBI) and a reaction (Reactome).
-  is_a: annotation
-  mixins:
-  - biolink:MolecularActivityToPathwayAssociation
-  biolink_predicate: biolink:participates_in
-  inherit_properties: true
-  represented_as: edge
-  input_label: small_molecule_to_reaction
-  output_label: participates_in
-  source: small molecule
-  target: reaction
-  kgx_properties:
-    subject_category: biolink:SmallMolecule
-    object_category: biolink:MolecularActivity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-so subclass of:
-  is_a: subclass of
-  inherit_properties: true
-  represented_as: edge
-  input_label: so_subclass_of
-  output_label: is_a
-  biolink_predicate: biolink:subclass_of
-  source: sequence type
-  target: sequence type
-  kgx_properties:
-    subject_category: biolink:OntologyClass
-    object_category: biolink:OntologyClass
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-structural_variant overlaps feature:
-  is_a: association
-  biolink_predicate: biolink:overlaps
-  represented_as: edge
-  input_label: structural_variant_overlaps_feature
-  output_label: overlaps
-  source: structural variant
-  target: biological entity
-  kgx_properties:
-    subject_category: biolink:SequenceVariant
-    object_category: biolink:GenomicEntity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
-structural_variant overlaps gene:
-  is_a: association
-  biolink_predicate: biolink:overlaps
-  represented_as: edge
-  input_label: structural_variant_overlaps_gene
-  output_label: overlaps
-  source: structural variant
-  target: gene
-
-structural_variant overlaps non_coding_rna:
-  is_a: association
-  biolink_predicate: biolink:overlaps
-  represented_as: edge
-  input_label: structural_variant_overlaps_non_coding_rna
-  output_label: overlaps
-  source: structural variant
-  target: non_coding_rna
-
-structural_variant overlaps promoter:
-  is_a: association
-  biolink_predicate: biolink:overlaps
-  represented_as: edge
-  input_label: structural_variant_overlaps_promoter
-  output_label: overlaps
-  source: structural variant
-  target: promoter
-
-subclass of:
-  is_a: annotation
-  mixins:
-  - biolink:SubclassOf
-  biolink_predicate: biolink:subclass_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: subclass_of
-  source: ontology term
-  target: ontology term
-  kgx_properties:
-    subject_category: biolink:OntologyClass
-    object_category: biolink:OntologyClass
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties: {}
-
-super enhancer to gene association:
-  description: An association between a super enhancer and a gene
-  is_a: regulatory association
-  biolink_predicate: biolink:associated_with
-  inherit_properties: true
-  represented_as: edge
-  input_label: super_enhancer_gene
-  output_label: associated_with
-  source: super enhancer
-  target: gene
-  kgx_properties:
-    subject_category: biolink:RegulatoryRegion
-    object_category: biolink:Gene
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    score: float
-    biological_context: str
-
-tissue part of anatomy:
-  is_a: part of
-  biolink_predicate: biolink:part_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: tissue_part_of_anatomy
-  output_label: part_of
-  kgx_properties:
-    subject_category: biolink:AnatomicalEntity
-    object_category: biolink:AnatomicalEntity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  description: Cross-ontology relation linking a BRENDA Tissue Ontology (BTO) term
-    to an UBERON anatomy term.
-  source: tissue
-  target: anatomy
-
-transcribes to:
-  represented_as: edge
-  is_a: expression
-  biolink_predicate: biolink:TranscriptToGeneRelationship
-  inherit_properties: true
-  input_label: transcribes_to
-  source: gene
-  target: transcript
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:Transcript
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-    category: biolink:Association
-  description: inverse of transcribed from
-  exact_mappings:
-  - RO:0002511
-  - SIO:010080
-
-transcription factor to gene association:
-  description: An regulatory association between a transcription factor and its target
-    gene
-  is_a: regulatory association
-  biolink_predicate: biolink:regulates
-  inherit_properties: true
-  represented_as: edge
-  input_label: tf_gene
-  output_label: regulates
-  source: gene
-  target: gene
-  kgx_properties:
-    subject_category: biolink:Gene
-    object_category: biolink:Gene
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  properties:
-    evidence: str[]
-    detection_method: str
-    database: str[]
-    evidence_type: str
-
-translates to:
-  is_a: expression
-  biolink_predicate: biolink:translates_to
-  inherit_properties: true
-  represented_as: edge
-  input_label: translates_to
-  source: transcript
-  target: protein
-  inverse: translation of
-  kgx_properties:
-    subject_category: biolink:Transcript
-    object_category: biolink:Protein
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-  description: x (amino acid chain/polypeptide) is the ribosomal translation of y
-    (transcript) if and only if a ribosome reads y (transcript) through a series of
-    triplet codon-amino acid adaptor activities (GO:0030533) and produces x (amino
-    acid chain/polypeptide)
-  close_mappings:
-  - RO:0002513
-  - SIO:010082
-
-uberon subclass of:
-  is_a: subclass of
-  mixins:
-  - biolink:AnatomicalEntityToAnatomicalEntityAssociation
-  biolink_predicate: biolink:subclass_of
-  inherit_properties: true
-  represented_as: edge
-  input_label: uberon_subclass_of
-  output_label: is_a
-  source: anatomy
-  target: anatomy
-  kgx_properties:
-    subject_category: biolink:AnatomicalEntity
-    object_category: biolink:AnatomicalEntity
-    knowledge_level: knowledge_assertion
-    agent_type: manual_agent
-
 allele:
   represented_as: node
   input_label: allele
@@ -2457,7 +546,7 @@ allele:
       type: int
       biolink: taxon
       range: biolink:OrganismTaxon
-  description: Different versions of the same variant (in a specific  locus) are called
+  description: Different versions of the same variant (in a specific locus) are called
     alleles[1, 2]. Most commonly used referring to genes.
   kgx_properties:
     category: biolink:Allele
@@ -2684,6 +773,1464 @@ signaling pathway gene group:
   kgx_properties:
     category: biolink:Pathway
 
+
+##################             EDGES   SECTION             ####################
+
+annotation:
+  is_a: related to at concept level
+  mixins:
+  - biolink:Association
+  biolink_predicate: biolink:related_to
+  represented_as: edge
+  input_label: annotation
+  kgx_properties:
+    subject_category: biolink:OntologyClass
+    object_category: biolink:NamedThing
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  description: An association between a gene/ontology term and another entity
+  properties:
+    source:
+      type: str
+      biolink: knowledge_source
+    source_url:
+      type: str
+      biolink: source_web_page
+
+association:
+  description: A typed association between two entities that represents some form
+    of relationship or connection in a biomedical context.
+  abstract: true
+  represented_as: edge
+  properties:
+    source:
+      type: str
+      biolink: knowledge_source
+    source_url:
+      type: str
+      biolink: source_web_page
+    knowledge_level:
+      type: str
+      const: knowledge_assertion
+    agent_type:
+      type: str
+      const: manual_agent
+  kgx_properties:
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+biological process gene:
+  is_a: go gene
+  biolink_predicate: biolink:involved_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: biological_process_gene
+  output_label: involved_in
+  source: gene
+  target: biological process
+  gx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:BiologicalProcess
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+biological process gene product:
+  is_a: go gene product
+  biolink_predicate: biolink:involved_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: biological_process_gene_product
+  output_label: involved_in
+  source: protein
+  target: biological process
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:BiologicalProcess
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+biological process rna:
+  is_a: annotation
+  mixins:
+  - biolink:annotation
+  biolink_predicate: biolink:participates_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: biological_process_rna
+  output_label: participates_in
+  source: non coding rna
+  target: biological process
+  kgx_properties:
+    subject_category: biolink:RNAProduct
+    object_category: biolink:BiologicalProcess
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+biological process subclass:
+  is_a: subclass of
+  biolink_predicate: biolink:subclass_of
+  inherit_properties: true
+  represented_as: edge
+  input_label: biological_process_subclass_of
+  output_label: is_a
+  source: biological process
+  target: biological process
+  kgx_properties:
+    subject_category: biolink:BiologicalProcess
+    object_category: biolink:BiologicalProcess
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+catalyst protein to reaction or pathway association:
+  is_a: annotation
+  biolink_predicate: biolink:regulates
+  inherit_properties: true
+  description: holds between a protein playing a catalyst role in a reaction and a pathway
+  represented_as: edge
+  input_label: regulates
+  source: protein
+  target: biolink:BiologicalProcessOrActivity
+  properties:
+    relation_ontology_term: str
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+cellular component gene:
+  is_a: go gene
+  biolink_predicate: biolink:CellularComponent
+  inherit_properties: true
+  represented_as: edge
+  input_label: cellular_component_gene
+  source: gene
+  target: cellular component
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:CellularComponent
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+cellular component gene located in:
+  is_a: cellular component gene
+  biolink_predicate: biolink:located_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: cellular_component_gene_located_in
+  output_label: located_in
+  source: gene
+  target: cellular component
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:CellularComponent
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+cellular component gene part of:
+  is_a: cellular component gene
+  biolink_predicate: biolink:part_of
+  inherit_properties: true
+  represented_as: edge
+  input_label: cellular_component_gene_part_of
+  output_label: part_of
+  source: gene
+  target: cellular component
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:CellularComponent
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+cellular component gene product:
+  is_a: go gene product
+  biolink_predicate: biolink:located_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: cellular_component_gene_product
+  source: protein
+  target: cellular component
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:CellularComponent
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+cellular component gene product located in:
+  is_a: cellular component gene product
+  biolink_predicate: biolink:located_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: cellular_component_gene_product_located_in
+  output_label: located_in
+  source: protein
+  target: cellular component
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:CellularComponent
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+cellular component gene product part of:
+  is_a: cellular component gene product
+  biolink_predicate: biolink:part_of
+  inherit_properties: true
+  represented_as: edge
+  input_label: cellular_component_gene_product_part_of
+  output_label: part_of
+  source: protein
+  target: cellular component
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:CellularComponent
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+cellular component rna:
+  is_a: annotation
+  mixins:
+  - biolink:annotation
+  biolink_predicate: biolink:located_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: cellular_component_rna
+  output_label: located_in
+  source: non coding rna
+  target: cellular component
+  kgx_properties:
+    subject_category: biolink:RNAProduct
+    object_category: biolink:CellularComponent
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+cellular component subclass:
+  is_a: subclass of
+  biolink_predicate: biolink:subclass_of
+  inherit_properties: true
+  represented_as: edge
+  input_label: cellular_component_subclass_of
+  output_label: is_a
+  source: cellular component
+  target: cellular component
+  kgx_properties:
+    subject_category: biolink:CellularComponent
+    object_category: biolink:CellularComponent
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+chebi subclass of:
+  is_a: subclass of
+  inherit_properties: true
+  represented_as: edge
+  input_label: chebi_subclass_of
+  output_label: is_a
+  biolink_predicate: biolink:subclass_of
+  source: small molecule
+  target: small molecule
+  kgx_properties:
+    subject_category: biolink:ChemicalEntity
+    object_category: biolink:ChemicalEntity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+chemical_substance part_of chemical_substance:
+  is_a: association
+  biolink_predicate: biolink:part_of
+  represented_as: edge
+  input_label: chemical_substance_part_of_chemical_substance
+  output_label: part_of
+  source: small molecule
+  target: small molecule
+  properties:
+    evidence:
+      type: str[]
+      biolink: has_evidence
+  kgx_properties:
+    subject_category: biolink:ChemicalEntity
+    object_category: biolink:ChemicalEntity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+child pathway of:
+  is_a: annotation
+  biolink_predicate: biolink:part_of
+  inherit_properties: true
+  description: holds between two pathways where the domain class is a child pathway
+    of the range class
+  represented_as: edge
+  input_label: child_pathway_of
+  source: pathway
+  target: pathway
+  kgx_properties:
+    subject_category: biolink:Pathway
+    object_category: biolink:Pathway
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+do subclass of:
+  is_a: subclass of
+  inherit_properties: true
+  represented_as: edge
+  input_label: do_subclass_of
+  output_label: is_a
+  biolink_predicate: biolink:subclass_of
+  source: disease
+  target: disease
+  kgx_properties:
+    subject_category: biolink:Disease
+    object_category: biolink:Disease
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+efo subclass of:
+  is_a: subclass of
+  biolink_predicate: biolink:subclass_of
+  inherit_properties: true
+  represented_as: edge
+  input_label: efo_subclass_of
+  output_label: is_a
+  source: experimental factor
+  target: experimental factor
+  kgx_properties:
+    subject_category: biolink:OntologyClass
+    object_category: biolink:OntologyClass
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+exon part_of gene:
+  is_a: related to at instance
+  mixins:
+  - biolink:SequenceFeatureRelationship
+  biolink_predicate: biolink:part_of
+  description: For example, a particular exon is part of a particular transcript or gene
+  represented_as: edge
+  input_label: part_of_gene
+  output_label: part_of
+  source: exon
+  target: gene
+  properties:
+    source:
+      type: str
+      biolink: provided_by
+    source_url:
+      type: str
+      biolink: source_web_page
+    taxon_id:
+      description: Taxon ID for the organism (e.g., 7227 for fruit fly, 9606 for human)
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: biolink:Transcript
+    object_category: biolink:Exon
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+exon part_of transcript:
+  is_a: related to at instance
+  mixins:
+  - biolink:ExonToTranscriptRelationship
+  biolink_predicate: biolink:has_part
+  description: An association between an exon and its transcript
+  represented_as: edge
+  input_label: part_of_transcript
+  output_label: part_of
+  source: exon
+  target: transcript
+  properties:
+    source:
+      type: str
+      biolink: provided_by
+    source_url:
+      type: str
+      biolink: source_web_page
+    taxon_id:
+      description: Taxon ID for the organism (e.g., 7227 for fruit fly, 9606 for human)
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: biolink:Transcript
+    object_category: biolink:Exon
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+expressed in:
+  description: holds between a gene and an ontology term in which it is expressed
+  is_a: expression
+  mixins:
+  - biolink:GeneToExpressionSiteAssociation
+  biolink_predicate: biolink:expressed_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: expressed_in
+  source: gene
+  target: ontology term
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:OntologyClass
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    score:
+      type: float
+      biolink: has_quantitative_value
+    p_value:
+      type: float
+      biolink: has_quantitative_value
+
+expression:
+  is_a: association
+  biolink_predicate: biolink:related_to
+  represented_as: edge
+  input_label: expression
+  description: An association between a gene and its expression
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:GeneOrGeneProduct
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    source:
+      type: str
+      biolink: knowledge_source
+    source_url:
+      type: str
+      biolink: source_web_page
+
+gene biomarker via orthology disease:
+  description: A gene is a biomarker for a disease via orthology relationship. From
+    Alliance for Genome Resources.
+  is_a: association
+  mixins:
+  - biolink:Association
+  biolink_predicate: biolink:biomarker_for
+  inherit_properties: true
+  represented_as: edge
+  input_label: biomarker_via_orthology
+  source: gene
+  target: disease
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:Disease
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    taxon_id:
+      type: integer
+    evidence_code:
+      type: string
+    evidence_code_name:
+      type: string
+    reference:
+      type: string
+    date:
+      type: string
+    data_source:
+      type: string
+    with_ortholog:
+      type: string
+    inferred_from_id:
+      type: string
+    inferred_from_symbol:
+      type: string
+
+gene implicated via orthology disease:
+  description: A gene is implicated in a disease via orthology relationship. From
+    Alliance for Genome Resources.
+  is_a: association
+  mixins:
+  - biolink:Association
+  biolink_predicate: biolink:implicated_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: implicated_via_orthology
+  source: gene
+  target: disease
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:Disease
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    taxon_id:
+      type: integer
+    evidence_code:
+      type: string
+    evidence_code_name:
+      type: string
+    reference:
+      type: string
+    date:
+      type: string
+    data_source:
+      type: string
+    with_ortholog:
+      type: string
+    inferred_from_id:
+      type: string
+    inferred_from_symbol:
+      type: string
+
+gene is implicated in disease:
+  description: A gene is implicated in a disease. From Alliance for Genome Resources.
+  is_a: association
+  mixins:
+  - biolink:Association
+  biolink_predicate: biolink:implicated_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: is_implicated_in
+  source: gene
+  target: disease
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:Disease
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    taxon_id:
+      type: integer
+    evidence_code:
+      type: string
+    evidence_code_name:
+      type: string
+    reference:
+      type: string
+    date:
+      type: string
+    data_source:
+      type: string
+    with_ortholog:
+      type: string
+    inferred_from_id:
+      type: string
+    inferred_from_symbol:
+      type: string
+
+gene to disease association:
+  description: An association between a gene and a disease identifier (e.g., OMIM, ORPHA).
+  is_a: association
+  mixins:
+  - biolink:GeneToDiseaseAssociation
+  biolink_predicate: biolink:associated_with
+  inherit_properties: true
+  represented_as: edge
+  input_label: gene_disease
+  output_label: associated_with
+  source: gene
+  target: disease
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:Disease
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    gene_symbol:
+      type: str
+    association_type:
+      type: str
+    source_ref:
+      type: str
+
+gene to disease marker association:
+  description: Gene is a marker for a disease
+  is_a: association
+  mixins:
+  - biolink:Association
+  biolink_predicate: biolink:model_of
+  inherit_properties: true
+  represented_as: edge
+  input_label: is_marker_for
+  source: gene
+  target: disease
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:Disease
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    taxon_id:
+      type: integer
+    evidence_code:
+      type: string
+    evidence_code_name:
+      type: string
+    reference:
+      type: string
+    date:
+      type: string
+    data_source:
+      type: string
+    with_ortholog:
+      type: string
+    inferred_from_id:
+      type: string
+    inferred_from_symbol:
+      type: string
+
+gene to disease model association:
+  description: Gene is a model for disease
+  is_a: association
+  mixins:
+  - biolink:Association
+  biolink_predicate: biolink:model_of
+  inherit_properties: true
+  represented_as: edge
+  input_label: is_model_of
+  source: gene
+  target: disease
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:Disease
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    taxon_id:
+      type: integer
+    evidence_code:
+      type: string
+    evidence_code_name:
+      type: string
+    reference:
+      type: string
+    date:
+      type: string
+    data_source:
+      type: string
+    with_ortholog:
+      type: string
+    inferred_from_id:
+      type: string
+    inferred_from_symbol:
+      type: string
+
+gene to gene coexpression association:
+  description: Indicates that two genes are co-expressed, generally under the same conditions.
+  is_a: expression
+  mixins:
+  - biolink:GeneToGeneCoexpressionAssociation
+  biolink_predicate: biolink:coexpressed_with
+  inherit_properties: true
+  represented_as: edge
+  input_label: coexpressed_with
+  source: gene
+  target: gene
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:Gene
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    score:
+      type: float
+      biolink: has_quantitative_value
+
+gene to pathway association:
+  description: An interaction between a gene or gene product and a biological process or pathway.
+  is_a: annotation
+  mixins:
+  - biolink:GeneToPathwayAssociation
+  biolink_predicate: biolink:participates_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: genes_pathways
+  output_label: participates_in
+  source:
+  - gene
+  - transcript
+  - protein
+  target: pathway
+  kgx_properties:
+    subject_category: biolink:GeneOrGeneProduct
+    object_category: biolink:Pathway
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+gene to phenotype association:
+  description: An association between a gene and a phenotype (HPO term).
+  is_a: association
+  mixins:
+  - biolink:GeneToPhenotypicFeatureAssociation
+  biolink_predicate: biolink:has_phenotype
+  inherit_properties: true
+  represented_as: edge
+  input_label: gene_phenotype
+  output_label: involved_in
+  source: gene
+  target: phenotype
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:PhenotypicFeature
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    gene_symbol:
+      type: str
+    phenotype_name:
+      type: str
+    frequency:
+      type: str
+    disease_id:
+      type: str
+
+gene to reaction association:
+  description: An interaction between a gene or a gene product (gogp) and a reaction (Reactome).
+  is_a: annotation
+  biolink_predicate: biolink:participates_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: gene_or_gene_product_reaction
+  output_label: involved_in
+  source: biolink:GeneOrGeneProduct
+  target: reaction
+  kgx_properties:
+    subject_category: biolink:GeneOrGeneProduct
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+go gene:
+  is_a: annotation
+  biolink_predicate: biolink:has_gene_product
+  inherit_properties: true
+  represented_as: edge
+  input_label: go_gene
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:OntologyClass
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    db_reference:
+      type: str[]
+      biolink: publication
+    evidence:
+      type: str
+      biolink: has_evidence
+    taxon_id:
+      type: str
+      biolink: taxon
+
+go gene product:
+  is_a: annotation
+  mixins:
+  - biolink:GeneToGoTermAssociation
+  biolink_predicate: biolink:has_gene_product
+  inherit_properties: true
+  represented_as: edge
+  input_label: go_gene_product
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:OntologyClass
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    db_reference:
+      type: str[]
+      biolink: publication
+    evidence:
+      type: str
+      biolink: has_evidence
+    taxon_id:
+      type: str
+      biolink: taxon
+
+has part:
+  is_a: annotation
+  biolink_predicate: biolink:has_part
+  inherit_properties: true
+  represented_as: edge
+  input_label: has_part
+  source: ontology term
+  target: ontology term
+  kgx_properties:
+    subject_category: biolink:OntologyClass
+    object_category: biolink:OntologyClass
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+has xref:
+  is_a: annotation
+  mixins:
+  - biolink:Association
+  biolink_predicate: biolink:xref
+  represented_as: edge
+  input_label: has_xref
+  output_label: has_xref
+  source: biological entity
+  target: biological entity
+  kgx_properties:
+    subject_category: biolink:NamedThing
+    object_category: biolink:NamedThing
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    xref_db:
+      type: str
+      biolink: knowledge_source
+    evidence:
+      type: str[]
+      biolink: has_evidence
+
+input role protein to reaction or pathway association:
+  is_a: annotation
+  biolink_predicate: biolink:is_input_of
+  inherit_properties: true
+  description: holds between a protein playing an input role in a reaction and a pathway
+  represented_as: edge
+  input_label: enables
+  source: protein
+  target: biolink:BiologicalProcessOrActivity
+  properties:
+    relation_ontology_term: str
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+mi subclass of:
+  is_a: subclass of
+  inherit_properties: true
+  represented_as: edge
+  input_label: mi_subclass_of
+  output_label: is_a
+  biolink_predicate: biolink:subclass_of
+  source: molecular interaction
+  target: molecular interaction
+  kgx_properties:
+    subject_category: biolink:OntologyClass
+    object_category: biolink:OntologyClass
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+molecular function gene:
+  is_a: go gene
+  biolink_predicate: biolink:enables
+  inherit_properties: true
+  represented_as: edge
+  input_label: molecular_function_gene
+  output_label: enables
+  source: gene
+  target: molecular function
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+molecular function gene product:
+  is_a: go gene product
+  biolink_predicate: biolink:enables
+  inherit_properties: true
+  represented_as: edge
+  input_label: molecular_function_gene_product
+  output_label: enables
+  source: protein
+  target: molecular function
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+molecular function rna:
+  is_a: annotation
+  mixins:
+  - biolink:annotation
+  biolink_predicate: biolink:enables
+  inherit_properties: true
+  represented_as: edge
+  input_label: molecular_function_rna
+  output_label: enables
+  source: non coding rna
+  target: molecular function
+  kgx_properties:
+    subject_category: biolink:RNAProduct
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+molecular function subclass:
+  is_a: subclass of
+  mixins:
+  - biolink:MolecularActivityToMolecularActivityAssociation
+  biolink_predicate: biolink:subclass_of
+  inherit_properties: true
+  represented_as: edge
+  input_label: molecular_function_subclass_of
+  output_label: is_a
+  source: molecular function
+  target: molecular function
+  kgx_properties:
+    subject_category: biolink:MolecularActivity
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+negative role protein to reaction or pathway association:
+  is_a: annotation
+  biolink_predicate: biolink:regulates
+  inherit_properties: true
+  description: holds between a protein playing a negative role in a reaction and a pathway
+  represented_as: edge
+  input_label: negatively_regulates
+  source: protein
+  target: biolink:BiologicalProcessOrActivity
+  properties:
+    relation_ontology_term: str
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+orthology association:
+  description: Non-directional association between two genes indicating an orthology
+    relation (purl.obolibrary.org/obo/RO_HOM0000017)
+  is_a: related to at instance level
+  represented_as: edge
+  input_label: orthologs_genes
+  biolink_predicate: biolink:ortholog_of
+  source: gene
+  target: gene
+  properties:
+    DIOPT_score:
+      type: int
+      biolink: has_quantitative_value
+    hsa_hgnc_id:
+      type: str
+      biolink: id
+    hsa_omim_id:
+      type: str
+      biolink: id
+    hsa_omim_phenotype_ids:
+      type: str
+      biolink: has_phenotype
+    hsa_omim_phenotype_ids_names:
+      type: str
+      biolink: has_phenotype_label
+    source_organism:
+      type: str
+      biolink: in_taxon
+    target_organism:
+      type: str
+      biolink: in_taxon
+    taxon_id:
+      description: Taxon ID for the organism (e.g., 7227 for fruit fly, 9606 for human)
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:Gene
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+output role protein to reaction or pathway association:
+  is_a: annotation
+  biolink_predicate: biolink:produced_by
+  inherit_properties: true
+  description: holds between a protein playing an output role in a reaction and a pathway
+  represented_as: edge
+  input_label: produced_by
+  source: protein
+  target: biolink:BiologicalProcessOrActivity
+  properties:
+    relation_ontology_term: str
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+paralogy association:
+  description: Non-directional association between two genes indicating a paralogy
+    relation (purl.obolibrary.org/obo/RO_HOM0000011)
+  is_a: related to at instance level
+  represented_as: edge
+  input_label: paralogs_genes
+  biolink_predicate: biolink:paralog_of
+  source: gene
+  target: gene
+  properties:
+    source_symbol:
+      type: str
+      biolink: symbol
+    target_symbol:
+      type: str
+      biolink: symbol
+    DIOPT_score:
+      type: int
+      biolink: has_quantitative_value
+    taxon_id:
+      type: int
+      biolink: taxon
+      range: biolink:OrganismTaxon
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:Gene
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+parent pathway of:
+  is_a: annotation
+  biolink_predicate: biolink:has_part
+  inherit_properties: true
+  description: holds between two pathways where the domain class is a parent pathway
+    of the range class
+  represented_as: edge
+  input_label: parent_pathway_of
+  source: pathway
+  target: pathway
+  kgx_properties:
+    subject_category: biolink:Pathway
+    object_category: biolink:Pathway
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+part of:
+  is_a: annotation
+  biolink_predicate: biolink:part_of
+  inherit_properties: true
+  represented_as: edge
+  input_label: part_of
+  source: ontology term
+  target: ontology term
+  kgx_properties:
+    subject_category: biolink:OntologyClass
+    object_category: biolink:OntologyClass
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+pathway_to_biological_process:
+  is_a: association
+  biolink_predicate: biolink:participates_in
+  source: pathway
+  target: biological process
+  represented_as: edge
+  input_label: pathway_to_biological_process
+  output_label: equivalent_to
+  description: An association between a pathway and a biological process.
+  properties:
+    source:
+      type: str
+      biolink: knowledge_source
+    source_url:
+      type: str
+      biolink: source_web_page
+  kgx_properties:
+    subject_category: biolink:Pathway
+    object_category: biolink:BiologicalProcess
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+pathway_to_cellular_component:
+  is_a: association
+  source: pathway
+  target: cellular component
+  biolink_predicate: biolink:related_to
+  represented_as: edge
+  input_label: pathway_to_cellular_component
+  description: An association between a pathway and a cellular component.
+  properties: {}
+  kgx_properties:
+    subject_category: biolink:Pathway
+    object_category: biolink:CellularComponent
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+pathway_to_molecular_function:
+  is_a: association
+  source: pathway
+  target: molecular function
+  biolink_predicate: biolink:related_to
+  represented_as: edge
+  input_label: pathway_to_molecular_function
+  description: An association between a pathway and a molecular function.
+  properties: {}
+  kgx_properties:
+    subject_category: biolink:Pathway
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+positive role protein to reaction or pathway association:
+  is_a: annotation
+  biolink_predicate: biolink:regulates
+  inherit_properties: true
+  description: holds between a protein playing a positive role in a reaction and a pathway
+  represented_as: edge
+  input_label: positively_regulates
+  source: protein
+  target: biolink:BiologicalProcessOrActivity
+  properties:
+    relation_ontology_term: str
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+post translational interaction:
+  is_a: expression
+  biolink_predicate: biolink:interacts_with
+  inherit_properties: true
+  represented_as: edge
+  input_label: interacts_with
+  source: protein
+  target: protein
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:Protein
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    score:
+      type: float
+      biolink: has_quantitative_value
+    interaction_type:
+      type: str
+    reactome_pathway:
+      type: str
+
+promoter to gene association:
+  description: An association between a promoter and a gene
+  is_a: regulatory association
+  biolink_predicate: biolink:associated_with
+  inherit_properties: true
+  represented_as: edge
+  input_label: promoter_gene
+  output_label: associated_with
+  source: promoter
+  target: gene
+  kgx_properties:
+    subject_category: biolink:RegulatoryRegion
+    object_category: biolink:Gene
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    score:
+      type: float
+      biolink: has_quantitative_value
+    biological_context:
+      type: str
+      biolink: has_biological_sequence
+
+protein has_xref binding_site_ligand:
+  is_a: has xref
+  biolink_predicate: biolink:xref
+  inherit_properties: true
+  represented_as: edge
+  input_label: protein_has_xref_binding_site_ligand
+  output_label: has_xref
+  source: protein
+  target: small molecule
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:ChemicalEntity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+protein has_xref biological_process:
+  is_a: has xref
+  biolink_predicate: biolink:xref
+  inherit_properties: true
+  represented_as: edge
+  input_label: protein_has_xref_biological_process
+  output_label: has_xref
+  source: protein
+  target: biological process
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:BiologicalProcess
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+protein has_xref catalytic_activity:
+  is_a: has xref
+  biolink_predicate: biolink:xref
+  inherit_properties: true
+  represented_as: edge
+  input_label: protein_has_xref_catalytic_activity
+  output_label: has_xref
+  source: protein
+  target: small molecule
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:ChemicalEntity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+protein has_xref cellular_component:
+  is_a: has xref
+  biolink_predicate: biolink:xref
+  inherit_properties: true
+  represented_as: edge
+  input_label: protein_has_xref_cellular_component
+  output_label: has_xref
+  source: protein
+  target: cellular component
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:CellularComponent
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+protein has_xref cofactor:
+  is_a: has xref
+  biolink_predicate: biolink:xref
+  inherit_properties: true
+  represented_as: edge
+  input_label: protein_has_xref_cofactor
+  output_label: has_xref
+  source: protein
+  target: small molecule
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:ChemicalEntity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+protein has_xref gene:
+  is_a: has xref
+  biolink_predicate: biolink:xref
+  inherit_properties: true
+  represented_as: edge
+  input_label: protein_has_xref_gene
+  output_label: has_xref
+  source: protein
+  target: gene
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:Gene
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+protein has_xref molecular_function:
+  is_a: has xref
+  biolink_predicate: biolink:xref
+  inherit_properties: true
+  represented_as: edge
+  input_label: protein_has_xref_molecular_function
+  output_label: has_xref
+  source: protein
+  target: molecular function
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+protein has_xref protein:
+  is_a: has xref
+  biolink_predicate: biolink:xref
+  inherit_properties: true
+  represented_as: edge
+  input_label: protein_has_xref_protein
+  output_label: has_xref
+  source: protein
+  target: protein
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:Protein
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+protein has_xref transcript:
+  is_a: has xref
+  biolink_predicate: biolink:xref
+  inherit_properties: true
+  represented_as: edge
+  input_label: protein_has_xref_transcript
+  output_label: has_xref
+  source: protein
+  target: transcript
+  kgx_properties:
+    subject_category: biolink:Protein
+    object_category: biolink:Transcript
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+reaction to pathway association:
+  is_a: annotation
+  biolink_predicate: biolink:part_of
+  inherit_properties: true
+  description: holds between a reaction and a pathway
+  represented_as: edge
+  input_label: reaction_to_pathway
+  output_label: part_of
+  source: reaction
+  target: pathway
+  kgx_properties:
+    subject_category: biolink:MolecularActivity
+    object_category: biolink:Pathway
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+regulatory association:
+  is_a: association
+  biolink_predicate: biolink:related_to
+  represented_as: edge
+  input_label: regulatory_association
+  kgx_properties:
+    subject_category: biolink:GenomicEntity
+    object_category: biolink:GenomicEntity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    source:
+      type: str
+      biolink: knowledge_source
+    source_url:
+      type: str
+      biolink: source_web_page
+
+small molecule to pathway association:
+  description: An interaction between a small molecule (ChEBI) and a pathway (Reactome).
+  is_a: annotation
+  mixins:
+  - biolink:MolecularActivityToPathwayAssociation
+  biolink_predicate: biolink:participates_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: small_molecule_to_pathway
+  output_label: participates_in
+  source: small molecule
+  target: pathway
+  kgx_properties:
+    subject_category: biolink:SmallMolecule
+    object_category: biolink:Pathway
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+small molecule to reaction association:
+  description: An interaction between a small molecule (ChEBI) and a reaction (Reactome).
+  is_a: annotation
+  mixins:
+  - biolink:MolecularActivityToPathwayAssociation
+  biolink_predicate: biolink:participates_in
+  inherit_properties: true
+  represented_as: edge
+  input_label: small_molecule_to_reaction
+  output_label: participates_in
+  source: small molecule
+  target: reaction
+  kgx_properties:
+    subject_category: biolink:SmallMolecule
+    object_category: biolink:MolecularActivity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+so subclass of:
+  is_a: subclass of
+  inherit_properties: true
+  represented_as: edge
+  input_label: so_subclass_of
+  output_label: is_a
+  biolink_predicate: biolink:subclass_of
+  source: sequence type
+  target: sequence type
+  kgx_properties:
+    subject_category: biolink:OntologyClass
+    object_category: biolink:OntologyClass
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
+subclass of:
+  is_a: annotation
+  mixins:
+  - biolink:SubclassOf
+  biolink_predicate: biolink:subclass_of
+  inherit_properties: true
+  represented_as: edge
+  input_label: subclass_of
+  source: ontology term
+  target: ontology term
+  kgx_properties:
+    subject_category: biolink:OntologyClass
+    object_category: biolink:OntologyClass
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties: {}
+
+transcribes to:
+  represented_as: edge
+  is_a: expression
+  biolink_predicate: biolink:TranscriptToGeneRelationship
+  inherit_properties: true
+  input_label: transcribes_to
+  source: gene
+  target: transcript
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:Transcript
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+    category: biolink:Association
+  description: inverse of transcribed from
+  exact_mappings:
+  - RO:0002511
+  - SIO:010080
+
+transcription factor to gene association:
+  description: A regulatory association between a transcription factor and its target gene
+  is_a: regulatory association
+  biolink_predicate: biolink:regulates
+  inherit_properties: true
+  represented_as: edge
+  input_label: tf_gene
+  output_label: regulates
+  source: gene
+  target: gene
+  kgx_properties:
+    subject_category: biolink:Gene
+    object_category: biolink:Gene
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  properties:
+    evidence: str[]
+    detection_method: str
+    database: str[]
+    evidence_type: str
+
+translates to:
+  is_a: expression
+  biolink_predicate: biolink:translates_to
+  inherit_properties: true
+  represented_as: edge
+  input_label: translates_to
+  source: transcript
+  target: protein
+  inverse: translation of
+  kgx_properties:
+    subject_category: biolink:Transcript
+    object_category: biolink:Protein
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+  description: x (amino acid chain/polypeptide) is the ribosomal translation of y (transcript)
+  close_mappings:
+  - RO:0002513
+  - SIO:010082
+
+uberon subclass of:
+  is_a: subclass of
+  mixins:
+  - biolink:AnatomicalEntityToAnatomicalEntityAssociation
+  biolink_predicate: biolink:subclass_of
+  inherit_properties: true
+  represented_as: edge
+  input_label: uberon_subclass_of
+  output_label: is_a
+  source: anatomy
+  target: anatomy
+  kgx_properties:
+    subject_category: biolink:AnatomicalEntity
+    object_category: biolink:AnatomicalEntity
+    knowledge_level: knowledge_assertion
+    agent_type: manual_agent
+
 allele to allele genetic interaction:
   represented_as: edge
   input_label: allele_to_allele_genetic_interaction
@@ -2835,9 +2382,8 @@ FBdv subclass of:
     agent_type: manual_agent
 
 gene genetic association:
-  description: An association between a gene and another gene, i.e., a gene-level
-    genetic interactions in FlyBase. This data is computed from the allele-level genetic
-    interaction data captured by FlyBase curators.
+  description: An association between a gene and another gene computed from allele-level
+    genetic interaction data captured by FlyBase curators.
   is_a: regulatory association
   inherit_properties: true
   represented_as: edge
@@ -2863,9 +2409,8 @@ gene genetic association:
     agent_type: manual_agent
 
 gene to group association:
-  description: 'An association between a gene and a group of genes: genes are grouped
-    into gene groups based on shared characteristics, such as sequence, biological
-    function, or participation in a biological process'
+  description: An association between a gene and a group of genes based on shared
+    characteristics such as sequence, biological function, or participation in a process.
   is_a: related to at instance level
   represented_as: edge
   input_label: grouped_into
@@ -2884,9 +2429,7 @@ gene to group association:
     agent_type: manual_agent
 
 gene to metabolic pathway group association:
-  description: 'An association between a gene and a group of genes: genes are grouped
-    into gene groups based on shared characteristics, such as sequence, biological
-    function, or participation in a biological process'
+  description: An association between a gene and a metabolic pathway gene group.
   is_a: related to at instance level
   represented_as: edge
   input_label: metabolic_pathway_grouped_into
@@ -2925,9 +2468,7 @@ gene to sequence type:
     agent_type: manual_agent
 
 gene to signaling pathway group association:
-  description: 'An association between a gene and a group of genes: genes are grouped
-    into gene groups based on shared characteristics, such as sequence, biological
-    function, or participation in a biological process'
+  description: An association between a gene and a signaling pathway gene group.
   is_a: related to at instance level
   represented_as: edge
   input_label: signaling_pathway_grouped_into

--- a/config/fly_base_schema/dmel_full_schema_config.yaml
+++ b/config/fly_base_schema/dmel_full_schema_config.yaml
@@ -4,8 +4,8 @@ Title: BioCypher graph schema configuration file (Biolink-adapted for dmel)
   represented_as: node
   is_a: position entity
   mixins:
-  - biolink:GenomicEntity-test
-  biolink_category: biolink:GenomicEntity-test
+  - biolink:GenomicEntity
+  biolink_category: biolink:GenomicEntity
   input_label: 3d_genome_structure
   inherit_properties: true
   description: A region of the genome that is associated with 3D genome structure
@@ -54,8 +54,8 @@ chromosome chain:
   represented_as: node
   is_a: position entity
   mixins:
-  - biolink:GenomicEntity-test
-  biolink_category: biolink:GenomicEntity-test
+  - biolink:GenomicEntity
+  biolink_category: biolink:GenomicEntity
   inherit_properties: true
   input_label: chromosome_chain
   properties:
@@ -71,9 +71,9 @@ coding element:
   represented_as: node
   is_a: biological entity
   mixins:
-  - biolink:GenomicEntity-test
+  - biolink:GenomicEntity
   - biolink:BiologicalEntity
-  biolink_category: biolink:GenomicEntity-test
+  biolink_category: biolink:GenomicEntity
   input_label: coding_element
   description: A region of a gene that codes for a protein or peptide
   properties:
@@ -370,9 +370,9 @@ position entity:
   represented_as: node
   is_a: biological entity
   mixins:
-  - biolink:GenomicEntity-test
+  - biolink:GenomicEntity
   - biolink:BiologicalEntity
-  biolink_category: biolink:GenomicEntity-test
+  biolink_category: biolink:GenomicEntity
   input_label: position_entity
   description: A biological entity that is defined by its position in the genome
   properties:
@@ -1830,8 +1830,8 @@ regulatory association:
   represented_as: edge
   input_label: regulatory_association
   kgx_properties:
-    subject_category: biolink:GenomicEntity-test
-    object_category: biolink:GenomicEntity-test
+    subject_category: biolink:GenomicEntity
+    object_category: biolink:GenomicEntity
     knowledge_level: knowledge_assertion
     agent_type: manual_agent
   properties:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
     restart: always
 
   redis:
+    container_name: annotation_redis
     image: redis:latest
     ports:
       - "${REDIS_DOCKER_PORT:-6380}:6379"

--- a/native/graph_module.cpp
+++ b/native/graph_module.cpp
@@ -1,6 +1,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include "graph_core.hpp"
+#include "neo4j_formatter.hpp"
 
 namespace py = pybind11;
 
@@ -133,4 +134,11 @@ PYBIND11_MODULE(graph_native, m) {
         }
         return res;
     });
+    m.def("format_neo4j_graph", [](py::object results, py::dict graph_components) {
+        return format_neo4j_graph(results, graph_components);
+    }, py::arg("results"), py::arg("graph_components"));
+
+    m.def("format_neo4j_count", [](py::object results, py::dict graph_components) {
+        return format_neo4j_count(results, graph_components);
+    }, py::arg("results"), py::arg("graph_components"));
 }

--- a/native/neo4j_formatter.cpp
+++ b/native/neo4j_formatter.cpp
@@ -1,0 +1,541 @@
+#include "neo4j_formatter.hpp"
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+#include <functional>
+#include <cctype>
+#include <iostream>
+
+namespace py = pybind11;
+
+// ---------------------------------------------------------------------------
+// Logging helper — all output goes to stderr so it appears in container logs
+// ---------------------------------------------------------------------------
+static void log(const std::string& level, const std::string& msg) {
+    std::cerr << "[neo4j_formatter][" << level << "] " << msg << std::endl;
+}
+#define LOG_INFO(msg)  log("INFO",  msg)
+#define LOG_WARN(msg)  log("WARN",  msg)
+#define LOG_ERROR(msg) log("ERROR", msg)
+#define LOG_DEBUG(msg) log("DEBUG", msg)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static const std::vector<std::string> NAMED_TYPES = {
+    "gene_name", "transcript_name", "protein_name", "pathway_name", "term_name"
+};
+
+static const std::unordered_map<std::string, std::string> NAMED_TYPES_DICT = {
+    {"gene",        "gene_name"},
+    {"transcript",  "transcript_name"},
+    {"protein",     "protein_name"},
+    {"pathway",     "pathway_name"},
+    {"term",        "term_name"},
+};
+
+static std::string to_lower(std::string s) {
+    for (auto& c : s) c = std::tolower(c);
+    return s;
+}
+
+static std::string get_type_name(const py::object& obj) {
+    try {
+        return py::str(obj.get_type().attr("__name__")).cast<std::string>();
+    } catch (...) {
+        return "<unknown>";
+    }
+}
+
+// Use attribute-based duck typing instead of class name comparison.
+// The Neo4j driver names relationship objects after their rel-type string
+// (e.g. "translates_to"), not "Relationship", so is_neo4j_type(..., "Relationship")
+// never matches. Check structural attributes instead.
+static bool is_neo4j_relationship(const py::object& obj) {
+    try {
+        return py::hasattr(obj, "start_node") &&
+               py::hasattr(obj, "end_node") &&
+               py::hasattr(obj, "type");
+    } catch (...) {
+        return false;
+    }
+}
+
+static bool is_neo4j_node(const py::object& obj) {
+    try {
+        return py::hasattr(obj, "labels") && py::hasattr(obj, "items");
+    } catch (...) {
+        return false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Graph formatting
+// ---------------------------------------------------------------------------
+
+py::dict format_neo4j_graph(py::object results, py::dict graph_components) {
+    LOG_INFO("format_neo4j_graph called");
+
+    py::list nodes;
+    py::list edges;
+    std::unordered_map<std::string, bool> node_seen;
+    std::unordered_set<std::string> edge_seen;
+
+    bool properties_enabled = true;
+    if (graph_components.contains("properties")) {
+        try {
+            properties_enabled = graph_components["properties"].cast<bool>();
+        } catch (...) {
+            LOG_WARN("Could not cast graph_components['properties'] to bool, defaulting to true");
+        }
+    }
+    LOG_INFO("properties_enabled = " + std::string(properties_enabled ? "true" : "false"));
+
+    // -- register a neo4j Node object --
+    auto register_node = [&](py::object item) {
+        try {
+            py::object labels = item.attr("labels");
+            std::string label = py::str(*labels.begin()).cast<std::string>();
+            std::string raw_id = py::str(item.attr("__getitem__")(py::str("id"))).cast<std::string>();
+            std::string node_id = label + " " + raw_id;
+
+            if (node_seen.count(node_id)) {
+                LOG_DEBUG("Node already seen, skipping: " + node_id);
+                return;
+            }
+            node_seen[node_id] = true;
+            LOG_INFO("Registering node: " + node_id);
+
+            py::dict node_data;
+            node_data["id"]   = py::str(node_id);
+            node_data["type"] = py::str(label);
+
+            int prop_count = 0;
+            for (auto kv : item.attr("items")()) {
+                py::tuple pair = kv.cast<py::tuple>();
+                std::string key = pair[0].cast<std::string>();
+                py::object  val = pair[1].cast<py::object>();
+                
+                std::unordered_set<std::string> to_avoid = {
+                    "id",
+                    "synonym",
+                    "build_id",
+                    "import_timestamp",
+                    "atomspace_version",
+                    "source_url"
+                };
+
+                if (properties_enabled) {
+                    if (to_avoid.find(key) == to_avoid.end()) {
+                        node_data[py::str(key)] = val;
+                        prop_count++;
+                    }
+                } else {
+                    for (const auto& nt : NAMED_TYPES) {
+                        if (key == nt) {
+                            node_data["name"] = val;
+                            break;
+                        }
+                    }
+                }
+            }
+            LOG_DEBUG("Node " + node_id + " properties copied: " + std::to_string(prop_count));
+
+            // name fallback
+            if (!node_data.contains("name")) {
+                std::string lower_label = to_lower(label);
+                auto it = NAMED_TYPES_DICT.find(lower_label);
+                if (it != NAMED_TYPES_DICT.end()) {
+                    std::string fallback_key = it->second;
+                    if (node_data.contains(py::str(fallback_key))) {
+                        node_data["name"] = node_data[py::str(fallback_key)];
+                        LOG_DEBUG("Node " + node_id + " name set from fallback key: " + fallback_key);
+                    } else {
+                        node_data["name"] = py::str(node_id);
+                        LOG_DEBUG("Node " + node_id + " name defaulted to node_id");
+                    }
+                } else {
+                    node_data["name"] = py::str(node_id);
+                    LOG_DEBUG("Node " + node_id + " name defaulted to node_id (no named_types entry)");
+                }
+            }
+
+            py::dict wrapped;
+            wrapped["data"] = node_data;
+            nodes.append(wrapped);
+            LOG_INFO("Node registered successfully: " + node_id);
+
+        } catch (const std::exception& e) {
+            LOG_ERROR("register_node threw exception: " + std::string(e.what()));
+        } catch (...) {
+            LOG_ERROR("register_node threw unknown exception");
+        }
+    };
+
+    // -- register a neo4j Relationship object --
+    auto register_relationship = [&](py::object item) {
+        try {
+            py::object start_node = item.attr("start_node");
+            py::object end_node   = item.attr("end_node");
+
+            std::string src_label = py::str(*start_node.attr("labels").begin()).cast<std::string>();
+            std::string tgt_label = py::str(*end_node.attr("labels").begin()).cast<std::string>();
+            std::string src_raw   = py::str(start_node.attr("__getitem__")(py::str("id"))).cast<std::string>();
+            std::string tgt_raw   = py::str(end_node.attr("__getitem__")(py::str("id"))).cast<std::string>();
+            std::string source_id = src_label + " " + src_raw;
+            std::string target_id = tgt_label + " " + tgt_raw;
+            std::string rel_type  = py::str(item.attr("type")).cast<std::string>();
+
+            std::string sig = source_id + " - " + rel_type + " - " + target_id;
+            LOG_INFO("Registering relationship: " + sig);
+
+            if (edge_seen.count(sig)) {
+                LOG_DEBUG("Relationship already seen, skipping: " + sig);
+                return;
+            }
+            edge_seen.insert(sig);
+
+            py::dict edge_data;
+            edge_data["edge_id"] = py::str(src_label + "_" + rel_type + "_" + tgt_label);
+            edge_data["label"]   = py::str(rel_type);
+            edge_data["source"]  = py::str(source_id);
+            edge_data["target"]  = py::str(target_id);
+
+            int prop_count = 0;
+            for (auto kv : item.attr("items")()) {
+                py::tuple pair = kv.cast<py::tuple>();
+                std::string key = pair[0].cast<std::string>();
+                py::object  val = pair[1].cast<py::object>();
+                if (key == "source") {
+                    edge_data["source_data"] = val;
+                } else {
+                    edge_data[py::str(key)] = val;
+                }
+                prop_count++;
+            }
+            LOG_DEBUG("Relationship " + sig + " properties copied: " + std::to_string(prop_count));
+
+            py::dict wrapped;
+            wrapped["data"] = edge_data;
+            edges.append(wrapped);
+            LOG_INFO("Relationship registered successfully: " + sig);
+
+            // always register endpoint nodes
+            LOG_DEBUG("Registering start_node of relationship: " + sig);
+            register_node(start_node);
+            LOG_DEBUG("Registering end_node of relationship: " + sig);
+            register_node(end_node);
+
+        } catch (const std::exception& e) {
+            LOG_ERROR("register_relationship threw exception: " + std::string(e.what()));
+        } catch (...) {
+            LOG_ERROR("register_relationship threw unknown exception");
+        }
+    };
+
+    // -- process a single value from a record --
+    // Relationship is identified by start_node + end_node + type attributes.
+    // Node is identified by labels + items attributes.
+    std::function<void(py::object)> process_value = [&](py::object item) {
+        std::string type_name = get_type_name(item);
+        LOG_DEBUG("process_value: type = " + type_name);
+
+        if (is_neo4j_relationship(item)) {
+            // Must check relationship before node — both have .items()
+            LOG_DEBUG("process_value: dispatching to register_relationship");
+            register_relationship(item);
+        } else if (is_neo4j_node(item)) {
+            LOG_DEBUG("process_value: dispatching to register_node");
+            register_node(item);
+        } else if (py::isinstance<py::list>(item)) {
+            LOG_DEBUG("process_value: item is a list (CALL subquery path)");
+            py::list lst = item.cast<py::list>();
+            LOG_DEBUG("process_value: list length = " + std::to_string(lst.size()));
+            for (auto entry : lst) {
+                py::object entry_obj = entry.cast<py::object>();
+                std::string entry_type = get_type_name(entry_obj);
+                LOG_DEBUG("process_value: list entry type = " + entry_type);
+                if (py::isinstance<py::dict>(entry_obj)) {
+                    LOG_DEBUG("process_value: list entry is dict, iterating values");
+                    for (auto kv : entry_obj.cast<py::dict>()) {
+                        process_value(kv.second.cast<py::object>());
+                    }
+                } else {
+                    process_value(entry_obj);
+                }
+            }
+        } else {
+            LOG_DEBUG("process_value: unhandled type = " + type_name + ", skipping");
+        }
+    };
+
+    // -- iterate records --
+    // into plain dicts/tuples, destroying type information needed for dispatch.
+    // Use record.keys() + record.__getitem__() to preserve raw Neo4j objects.
+    LOG_INFO("Starting record iteration");
+    int record_idx = 0;
+    for (auto record : results) {
+        py::object rec = record.cast<py::object>();
+        LOG_DEBUG("Processing record #" + std::to_string(record_idx));
+
+        try {
+            py::list keys = rec.attr("keys")().cast<py::list>();
+            LOG_DEBUG("Record #" + std::to_string(record_idx) +
+                      ": keys count = " + std::to_string(keys.size()));
+
+            for (auto key : keys) {
+                std::string key_str = key.cast<std::string>();
+                py::object val = rec.attr("__getitem__")(key).cast<py::object>();
+                LOG_DEBUG("Record #" + std::to_string(record_idx) +
+                          ": key = " + key_str +
+                          ", value type = " + get_type_name(val));
+                process_value(val);
+            }
+        } catch (const std::exception& e) {
+            LOG_ERROR("Record #" + std::to_string(record_idx) +
+                      ": key iteration failed: " + std::string(e.what()));
+        } catch (...) {
+            LOG_ERROR("Record #" + std::to_string(record_idx) +
+                      ": key iteration failed (unknown)");
+        }
+
+        record_idx++;
+    }
+
+    LOG_INFO("Record iteration complete. nodes=" + std::to_string(py::len(nodes)) +
+             " edges=" + std::to_string(py::len(edges)));
+
+    py::dict result;
+    result["nodes"] = nodes;
+    result["edges"] = edges;
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Count formatting
+// ---------------------------------------------------------------------------
+
+py::dict format_neo4j_count(py::object results, py::dict graph_components) {
+    LOG_INFO("format_neo4j_count called");
+
+    py::list results_list;
+    try {
+        results_list = results.cast<py::list>();
+    } catch (...) {
+        LOG_ERROR("format_neo4j_count: could not cast results to list");
+        return py::dict();
+    }
+
+    LOG_INFO("format_neo4j_count: results list size = " +
+             std::to_string(results_list.size()));
+
+    if (results_list.empty()) {
+        LOG_WARN("format_neo4j_count: empty results, returning empty dict");
+        return py::dict();
+    }
+
+    long node_count = 0;
+    long edge_count = 0;
+
+    try {
+        py::object first = results_list[0].cast<py::object>();
+        bool read_first = false;
+
+        // Try plain dict cast first
+        try {
+            py::dict first_dict = first.cast<py::dict>();
+            try {
+                node_count = first_dict["total_nodes"].cast<long>();
+                LOG_INFO("format_neo4j_count: total_nodes = " + std::to_string(node_count));
+            } catch (...) {
+                LOG_WARN("format_neo4j_count: could not read total_nodes from dict");
+            }
+            try {
+                edge_count = first_dict["total_edges"].cast<long>();
+                LOG_INFO("format_neo4j_count: total_edges = " + std::to_string(edge_count));
+            } catch (...) {
+                LOG_WARN("format_neo4j_count: could not read total_edges from dict");
+            }
+            read_first = true;
+        } catch (...) {
+            LOG_WARN("format_neo4j_count: first result is not a plain dict, trying Neo4j Record");
+        }
+
+        // Fall back to keys() + __getitem__ for Neo4j Record
+        if (!read_first) {
+            try {
+                py::list keys = first.attr("keys")().cast<py::list>();
+                LOG_DEBUG("format_neo4j_count: first result keys count = " +
+                          std::to_string(keys.size()));
+                for (auto key : keys) {
+                    std::string key_str = key.cast<std::string>();
+                    py::object val = first.attr("__getitem__")(key).cast<py::object>();
+                    LOG_DEBUG("format_neo4j_count: first result key = " + key_str);
+                    if (key_str == "total_nodes") {
+                        try {
+                            node_count = val.cast<long>();
+                            LOG_INFO("format_neo4j_count: total_nodes = " +
+                                     std::to_string(node_count));
+                        } catch (...) {
+                            LOG_WARN("format_neo4j_count: could not cast total_nodes");
+                        }
+                    } else if (key_str == "total_edges") {
+                        try {
+                            edge_count = val.cast<long>();
+                            LOG_INFO("format_neo4j_count: total_edges = " +
+                                     std::to_string(edge_count));
+                        } catch (...) {
+                            LOG_WARN("format_neo4j_count: could not cast total_edges");
+                        }
+                    }
+                }
+            } catch (...) {
+                LOG_ERROR("format_neo4j_count: keys() iteration also failed on first result");
+            }
+        }
+    } catch (...) {
+        LOG_ERROR("format_neo4j_count: failed to read first result row");
+    }
+
+    // Build aggregation maps from graph_components
+    std::unordered_map<std::string, long> node_agg;
+    std::unordered_map<std::string, long> edge_agg;
+
+    if (graph_components.contains("nodes")) {
+        try {
+            for (auto n : graph_components["nodes"].cast<py::list>()) {
+                std::string type = n.cast<py::dict>()["type"].cast<std::string>();
+                node_agg[type] = 0;
+                LOG_DEBUG("format_neo4j_count: tracking node type: " + type);
+            }
+        } catch (...) {
+            LOG_WARN("format_neo4j_count: failed to read graph_components nodes");
+        }
+    }
+
+    if (graph_components.contains("predicates")) {
+        try {
+            for (auto p : graph_components["predicates"].cast<py::list>()) {
+                std::string type = p.cast<py::dict>()["type"].cast<std::string>();
+                std::string key;
+                for (char c : type) key += (c == ' ') ? '_' : std::tolower(c);
+                edge_agg[key] = 0;
+                LOG_DEBUG("format_neo4j_count: tracking edge type: " + key);
+            }
+        } catch (...) {
+            LOG_WARN("format_neo4j_count: failed to read graph_components predicates");
+        }
+    }
+
+    // Aggregate counts by label from second result
+    if (results_list.size() > 1) {
+        try {
+            py::object second = results_list[1].cast<py::object>();
+            py::dict label_data;
+            bool got_data = false;
+
+            // Try plain dict cast first
+            try {
+                label_data = second.cast<py::dict>();
+                got_data = true;
+                LOG_DEBUG("format_neo4j_count: read label counts via direct dict cast");
+            } catch (...) {
+                LOG_WARN("format_neo4j_count: second result is not a plain dict, trying .data()");
+            }
+
+            // Fall back to .data()
+            if (!got_data) {
+                try {
+                    label_data = second.attr("data")().cast<py::dict>();
+                    got_data = true;
+                    LOG_DEBUG("format_neo4j_count: read label counts via .data()");
+                } catch (...) {
+                    LOG_WARN("format_neo4j_count: .data() also failed on second result");
+                }
+            }
+
+            // Fall back to keys() + __getitem__
+            if (!got_data) {
+                try {
+                    py::list keys = second.attr("keys")().cast<py::list>();
+                    for (auto key : keys) {
+                        std::string key_str = key.cast<std::string>();
+                        py::object val = second.attr("__getitem__")(key).cast<py::object>();
+                        label_data[py::str(key_str)] = val;
+                    }
+                    got_data = true;
+                    LOG_DEBUG("format_neo4j_count: read label counts via keys() + __getitem__");
+                } catch (...) {
+                    LOG_ERROR("format_neo4j_count: all methods failed to read second result");
+                }
+            }
+
+            if (got_data) {
+                for (auto kv : label_data) {
+                    std::string key = kv.first.cast<std::string>();
+                    long value = 0;
+                    try {
+                        value = kv.second.cast<long>();
+                    } catch (...) {
+                        LOG_WARN("format_neo4j_count: could not cast value for key: " + key);
+                    }
+
+                    // strip node_var prefix: "n5_Gene" -> "Gene", "p0_regulates" -> "regulates"
+                    size_t pos = key.find('_');
+                    std::string label_key = (pos != std::string::npos)
+                        ? key.substr(pos + 1)
+                        : key;
+
+                    LOG_DEBUG("format_neo4j_count: label key = " + label_key +
+                              ", value = " + std::to_string(value));
+
+                    if (node_agg.count(label_key)) {
+                        node_agg[label_key] += value;
+                        LOG_DEBUG("format_neo4j_count: added to node_agg[" + label_key +
+                                  "] = " + std::to_string(node_agg[label_key]));
+                    }
+                    if (edge_agg.count(label_key)) {
+                        edge_agg[label_key] += value;
+                        LOG_DEBUG("format_neo4j_count: added to edge_agg[" + label_key +
+                                  "] = " + std::to_string(edge_agg[label_key]));
+                    }
+                }
+            }
+        } catch (...) {
+            LOG_ERROR("format_neo4j_count: exception processing second result row");
+        }
+    }
+
+    // Build output lists
+    py::list node_count_by_label;
+    for (auto const& [k, v] : node_agg) {
+        py::dict entry;
+        entry["label"] = py::str(k);
+        entry["count"] = py::int_(v);
+        node_count_by_label.append(entry);
+        LOG_INFO("format_neo4j_count: node label count: " + k +
+                 " = " + std::to_string(v));
+    }
+
+    py::list edge_count_by_label;
+    for (auto const& [k, v] : edge_agg) {
+        py::dict entry;
+        entry["label"] = py::str(k);
+        entry["count"] = py::int_(v);
+        edge_count_by_label.append(entry);
+        LOG_INFO("format_neo4j_count: edge label count: " + k +
+                 " = " + std::to_string(v));
+    }
+
+    py::dict result;
+    result["node_count"]          = py::int_(node_count);
+    result["edge_count"]          = py::int_(edge_count);
+    result["node_count_by_label"] = node_count_by_label;
+    result["edge_count_by_label"] = edge_count_by_label;
+
+    LOG_INFO("format_neo4j_count complete: node_count=" + std::to_string(node_count) +
+             " edge_count=" + std::to_string(edge_count));
+    return result;
+}

--- a/native/neo4j_formatter.hpp
+++ b/native/neo4j_formatter.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+// Formats a list of Neo4j records into {"nodes": [...], "edges": [...]}
+// Handles flat Node/Relationship records AND CALL subquery list-of-maps results.
+py::dict format_neo4j_graph(py::object results, py::dict graph_components);
+
+// Formats count query results into
+// {"node_count", "edge_count", "node_count_by_label", "edge_count_by_label"}
+py::dict format_neo4j_count(py::object results, py::dict graph_components);

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pybind11.setup_helpers import Pybind11Extension, build_ext
 ext_modules = [
     Pybind11Extension(
         "graph_native",
-        ["native/graph_module.cpp", "native/graph_core.cpp"],
+        ["native/graph_module.cpp", "native/graph_core.cpp", "native/neo4j_formatter.cpp"],
         include_dirs=["native"],
         cxx_std=17,
     ),


### PR DESCRIPTION
## Cypher query engine
### Independent CALL arms
Each predicate group gets its own `CALL (anchor) { RETURN collect(DISTINCT {...}) }` block. No cross-product between branches. Always 1 row per anchor node.
### Anchor-first outer MATCH
`_find_anchor_node` now prefers nodes with property filters so the outer MATCH starts from the most specific node, not the most connected one.
### Multi-branch chain grouping
Greedy BFS groups all predicates sharing a non-anchor node into the same CALL arm. Fixes the split where `transcript->pathway` and `transcript->protein` landed in separate arms.
### Partial vs strict result mode
Two query modes controlled by the `strict` flag on `_build_call_subquery`:
- `strict=True` (default) — all CALL arms must return data. If any arm is empty the whole result is empty, enforcing full path traversal.
- `strict=False` — partial results allowed. Arms with data are returned even if others are empty, useful when the user explicitly opts into incomplete matches.

Implemented via `WITH * WHERE size(alias) > 0` applied after all CALL blocks when strict mode is on.
### Gene list queries
New `in_list_query_generator` supports gene list searches using `WITH [...] AS listA WHERE n.id IN listA`. Supports Ensembl IDs, gene names, and mixed property filters.
### Regex escaping for property values
Values like `Cr1a{}1259` are escaped via `re.escape()` before interpolation into `=~` patterns.

---

## Title generation
### List node labeling
List nodes (multiple gene IDs or names) are labeled by count rather than enumerating all values, e.g. `15 Genes` instead of `ENSG001, ENSG002, ...`.
### Duplicate fragment deduplication
Title fragments with the same verb and target are merged into a single fragment. Repeated fragments (e.g. `Transcript participates in a Pathway` appearing 3 times) are deduplicated to one occurrence.
### Two-list query titles
For gene list vs gene list queries, both list sizes are reflected in the title, e.g. `15 Genes regulate 7 Genes`.

---

## Unified result formatter (`result_formatter.py`)
Consolidates all result parsing logic from `CypherQueryGenerator`, MeTTa, and Mork into a single `Result_Formatter` class. `parse_and_serialize` now delegates to `self.formatter.format_result(...)`. Previously duplicated methods removed from `CypherQueryGenerator`.
Key fixes:
- CALL subquery results (list-of-maps) now correctly parsed - previously returned silent empty graph
- Relationship endpoint nodes always registered
- Count aggregation guards added for empty/None results

---

## Native C++ result formatter (`native/neo4j_formatter.cpp`)
C++ implementation of the result formatter exposed via pybind11. Currently replaces the Python formatter for Neo4j only. If the native module fails to load or raises at runtime, it falls back to the Python implementation automatically.
Files added/modified: `neo4j_formatter.hpp`, `neo4j_formatter.cpp`, `graph_module.cpp`, `setup.py`

---

## Fly schema representation (`SchemaManager.get_fly_schema_representation`)
Rewrote node and edge derivation logic to only surface types that exist in the fly Neo4j database.
- Nodes now derived from edges rather than the full schema, filtering out abstract parent types and human-only nodes with no fly data
- Abstract node labels (`biological entity`, `ontology term`, `genomic variant`, etc.) excluded from output
- Edges targeting abstract `ontology term` expanded to concrete subtypes (`anatomy`, `biological_process`, `cellular_component`, etc.)
- `input_label` used consistently as the Neo4j relationship key instead of `output_label`

---

## dmel primer schema (`dmel_primer_schema_config.yaml`)
Introduces a fly-specific primer schema, replacing `primer_schema_config.yaml` for the fly schema merge in `deps.py`. `primer_schema_config.yaml` is unchanged.
Removed node types (no data in dmel Neo4j database):
- `regulatory region`, `structural variant`, `sequence variant` - human-only
- `tad` - human and mouse only
- `transcription binding site` - fly data not yet available
- `cell type`, `cell line`, `tissue` - no fly entity links; some CL-prefixed IDs are stored under `anatomy` due to UBERON ontology

All edges referencing these node types removed as a consequence.

---

## Performance
| | Before | After |
|---|---|---|
| FTO star query | 24+ hrs | 118 ms |
| CALL subquery results | Silent empty graph | Correctly parsed |
| Result formatting | Python only | C++ native + Python fallback |