### PR TITLE
Add Kubernetes staging manifests for annotation service

### DIFF
--- a/k8s/staging/annotation/annotation-service.yaml
+++ b/k8s/staging/annotation/annotation-service.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: annotation-service-staging
+  namespace: annotation-staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: annotation-service-staging
+  template:
+    metadata:
+      labels:
+        app: annotation-service-staging
+    spec:
+      imagePullSecrets:
+        - name: dockerhub-creds
+      containers:
+        - name: annotation-service-staging
+          image: abdum1964/annotation:staging
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+          ports:
+            - containerPort: 5007
+          envFrom:
+            - secretRef:
+                name: annotation-secrets
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: annotation-service-staging
+  namespace: annotation-staging
+spec:
+  type: NodePort
+  selector:
+    app: annotation-service-staging
+  ports:
+    - port: 5007
+      targetPort: 5007
+      nodePort: 30501

--- a/k8s/staging/annotation/celery-worker.yaml
+++ b/k8s/staging/annotation/celery-worker.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: celery-worker-staging
+  namespace: annotation-staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: celery-worker-staging
+  template:
+    metadata:
+      labels:
+        app: celery-worker-staging
+    spec:
+      imagePullSecrets:
+        - name: dockerhub-creds
+      containers:
+        - name: celery-worker-staging
+          image: abdum1964/annotation:staging
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+          env:
+            - name: C_FORCE_ROOT
+              value: "true"
+          envFrom:
+            - secretRef:
+                name: annotation-secrets
+          command:
+            - "celery"
+            - "-A"
+            - "app.workers.celery_app"
+            - "worker"
+            - "--loglevel=info"

--- a/k8s/staging/annotation/mongodb.yaml
+++ b/k8s/staging/annotation/mongodb.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb-staging
+  namespace: annotation-staging
+spec:
+  selector:
+    matchLabels:
+      app: mongodb-staging
+  serviceName: mongodb-staging
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mongodb-staging
+    spec:
+      containers:
+        - name: mongodb-staging
+          image: mongo:latest
+          ports:
+            - containerPort: 27017
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: annotation-secrets
+                  key: MONGO_USER
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: annotation-secrets
+                  key: MONGO_PASS
+          volumeMounts:
+            - name: mongo-data
+              mountPath: /data/db
+  volumeClaimTemplates:
+    - metadata:
+        name: mongo-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb-staging
+  namespace: annotation-staging
+spec:
+  selector:
+    app: mongodb-staging
+  ports:
+    - port: 27017
+      targetPort: 27017

--- a/k8s/staging/annotation/redis.yaml
+++ b/k8s/staging/annotation/redis.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-staging
+  namespace: annotation-staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis-staging
+  template:
+    metadata:
+      labels:
+        app: redis-staging
+    spec:
+      containers:
+        - name: redis-staging
+          image: redis:latest
+          ports:
+            - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: annotation-staging
+spec:
+  selector:
+    app: redis-staging
+  ports:
+    - port: 6379
+      targetPort: 6379


### PR DESCRIPTION
Deploy annotation-service, celery-worker, MongoDB, and Redis to the annotation-staging namespace with resource limits, proper image pull policy, and Celery root execution suppor